### PR TITLE
applies case_sensitive via username_configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,9 @@ resource "aws_cognito_user_pool" "pool" {
   sms_authentication_message = var.sms_authentication_message
   sms_verification_message   = var.sms_verification_message
   username_attributes        = var.username_attributes
-  case_sensitive             = var.case_sensitive
+  username_configuration {
+    case_sensitive = var.case_sensitive
+  }
   lifecycle {
     ignore_changes = [
         admin_create_user_config.0.unused_account_validity_days


### PR DESCRIPTION
I was receiving the following error from the commit adding case_sensitive:

```
Error: Unsupported argument

  on terraform-aws-cognito-user-pool/main.tf line 12, in resource "aws_cognito_user_pool" "pool":
  12:   username_configuration = {

An argument named "username_configuration" is not expected here. Did you mean
to define a block of type "username_configuration"?
```

This pr fixes the error :)