### PR TITLE
Added hosted ui subdomain creation

### DIFF
--- a/route53.tf
+++ b/route53.tf
@@ -1,0 +1,26 @@
+locals {
+  domain_parts = split(".", var.domain)
+  parent_hosted_zone_parts = slice(local.domain_parts, 1, length(local.domain_parts))
+  parent_hosted_zone = join(".", local.parent_hosted_zone_parts)
+}
+
+data "aws_route53_zone" "custom_domain_zone" {
+  count = var.domain_certificate_arn == null ? 0 : 1
+
+  name = local.parent_hosted_zone
+}
+
+resource "aws_route53_record" "custom_domain_subdomain" {
+  count = var.domain_certificate_arn == null ? 0 : 1
+
+  zone_id = data.aws_route53_zone.custom_domain_zone[0].zone_id
+  name    = var.domain
+  type    = "A"
+  alias {
+    name = aws_cognito_user_pool_domain.domain[0].cloudfront_distribution_arn
+    // The following zone id is CloudFront.
+    // See https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-route53-aliastarget.html
+    zone_id = "Z2FDTNDATAQYW2"
+    evaluate_target_health = false
+  }
+}

--- a/route53.tf
+++ b/route53.tf
@@ -1,13 +1,16 @@
-locals {
-  domain_parts = split(".", var.domain)
-  parent_hosted_zone_parts = slice(local.domain_parts, 1, length(local.domain_parts))
-  parent_hosted_zone = join(".", local.parent_hosted_zone_parts)
-}
-
 data "aws_route53_zone" "custom_domain_zone" {
   count = var.domain_certificate_arn == null ? 0 : 1
-
-  name = local.parent_hosted_zone
+  
+  name = join(
+    ".",
+    slice(
+      split(".", var.domain),
+      1,
+      length(
+        split(".", var.domain)
+      )
+    )
+  )
 }
 
 resource "aws_route53_record" "custom_domain_subdomain" {


### PR DESCRIPTION
When a custom subdomain is used, after the aws_cognito_user_pool_domain resource is created you need to create a route53 alias record which points to the cloudfront distribution which was created by the user pool domain.

This PR adds the resource aws_route53_record to be automatically created if a custom domain is used (which you can tell is true if the user supplied an acm certificate arn, I believe this is only valid when used with a custom domain).

It's possible this would surprise anyone upgrading so perhaps if you're happy with the concept of this change generally I could also add a variable to control the creation of the record (say variable create_user_pool_domain_subdomain boolean defaulting to false to maintain backwards compatibility)