### PR TITLE
Use for_each for resources to avoid index changing in count

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -1,61 +1,78 @@
 resource "aws_cognito_user_pool_client" "client" {
-  count                                = length(local.clients)
-  allowed_oauth_flows                  = lookup(element(local.clients, count.index), "allowed_oauth_flows", null)
-  allowed_oauth_flows_user_pool_client = lookup(element(local.clients, count.index), "allowed_oauth_flows_user_pool_client", null)
-  allowed_oauth_scopes                 = lookup(element(local.clients, count.index), "allowed_oauth_scopes", null)
-  callback_urls                        = lookup(element(local.clients, count.index), "callback_urls", null)
-  default_redirect_uri                 = lookup(element(local.clients, count.index), "default_redirect_uri", null)
-  explicit_auth_flows                  = lookup(element(local.clients, count.index), "explicit_auth_flows", null)
-  generate_secret                      = lookup(element(local.clients, count.index), "generate_secret", null)
-  logout_urls                          = lookup(element(local.clients, count.index), "logout_urls", null)
-  name                                 = lookup(element(local.clients, count.index), "name", null)
-  read_attributes                      = lookup(element(local.clients, count.index), "read_attributes", null)
-  refresh_token_validity               = lookup(element(local.clients, count.index), "refresh_token_validity", null)
-  supported_identity_providers         = lookup(element(local.clients, count.index), "supported_identity_providers", null)
-  prevent_user_existence_errors        = lookup(element(local.clients, count.index), "prevent_user_existence_errors", null)
-  write_attributes                     = lookup(element(local.clients, count.index), "write_attributes", null)
-  user_pool_id                         = aws_cognito_user_pool.pool.id
-}
+  for_each = var.clients
 
-locals {
-  clients_default = [
-    {
-      allowed_oauth_flows                  = var.client_allowed_oauth_flows
-      allowed_oauth_flows_user_pool_client = var.client_allowed_oauth_flows_user_pool_client
-      allowed_oauth_scopes                 = var.client_allowed_oauth_scopes
-      callback_urls                        = var.client_callback_urls
-      default_redirect_uri                 = var.client_default_redirect_uri
-      explicit_auth_flows                  = var.client_explicit_auth_flows
-      generate_secret                      = var.client_generate_secret
-      logout_urls                          = var.client_logout_urls
-      name                                 = var.client_name
-      read_attributes                      = var.client_read_attributes
-      refresh_token_validity               = var.client_refresh_token_validity
-      supported_identity_providers         = var.client_supported_identity_providers
-      prevent_user_existence_errors        = var.client_prevent_user_existence_errors
-      write_attributes                     = var.client_write_attributes
-    }
-  ]
+  #######
+  # name: (Required) The name of the application client. The resource will only be created when at least 1 name value has been defined.
+  #######
+  name = each.key
 
-  # This parses vars.clients which is a list of objects (map), and transforms it to a tuple of elements to avoid conflict with  the ternary and local.clients_default
-  clients_parsed = [for e in var.clients : {
-    allowed_oauth_flows                  = lookup(e, "allowed_oauth_flows", null)
-    allowed_oauth_flows_user_pool_client = lookup(e, "allowed_oauth_flows_user_pool_client", null)
-    allowed_oauth_scopes                 = lookup(e, "allowed_oauth_scopes", null)
-    callback_urls                        = lookup(e, "callback_urls", null)
-    default_redirect_uri                 = lookup(e, "default_redirect_uri", null)
-    explicit_auth_flows                  = lookup(e, "explicit_auth_flows", null)
-    generate_secret                      = lookup(e, "generate_secret", null)
-    logout_urls                          = lookup(e, "logout_urls", null)
-    name                                 = lookup(e, "name", null)
-    read_attributes                      = lookup(e, "read_attributes", null)
-    refresh_token_validity               = lookup(e, "refresh_token_validity", null)
-    supported_identity_providers         = lookup(e, "supported_identity_providers", null)
-    prevent_user_existence_errors        = lookup(e, "prevent_user_existence_errors", null)
-    write_attributes                     = lookup(e, "write_attributes", null)
-    }
-  ]
+  ######################
+  # allowed_oauth_flows: (Optional) List of allowed OAuth flows (code, implicit, client_credentials).
+  ######################
+  allowed_oauth_flows = try(each.value.allowed_oauth_flows, null)
 
-  clients = length(var.clients) == 0 && (var.client_name == null || var.client_name == "") ? [] : (length(var.clients) > 0 ? local.clients_parsed : local.clients_default)
+  #######################################
+  # allowed_oauth_flows_user_pool_client: (Optional) Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools.
+  #######################################
+  allowed_oauth_flows_user_pool_client = try(each.value.allowed_oauth_flows_user_pool_client, null)
 
+  #######################
+  # allowed_oauth_scopes: (Optional) List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin).
+  #######################
+  allowed_oauth_scopes = try(each.value.allowed_oauth_scopes, null)
+
+  ################
+  # callback_urls: (Optional) List of allowed callback URLs for the identity providers.
+  ################
+  callback_urls = try(each.value.callback_urls, null)
+
+  #######################
+  # default_redirect_uri: (Optional) The default redirect URI. Must be in the list of callback URLs.
+  #######################
+  default_redirect_uri = try(each.value.default_redirect_uri, null)
+
+  ######################
+  # explicit_auth_flows: (Optional) List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH, ALLOW_ADMIN_USER_PASSWORD_AUTH, ALLOW_CUSTOM_AUTH, ALLOW_USER_PASSWORD_AUTH, ALLOW_USER_SRP_AUTH, ALLOW_REFRESH_TOKEN_AUTH).
+  ######################
+  explicit_auth_flows = try(each.value.explicit_auth_flows, null)
+
+  ##################
+  # generate_secret: (Optional) Should an application secret be generated.
+  ##################
+  generate_secret = try(each.value.generate_secret, null)
+
+  ##############
+  # logout_urls: (Optional) List of allowed logout URLs for the identity providers.
+  ##############
+  logout_urls = try(each.value.logout_urls, null)
+
+  ################################
+  # prevent_user_existence_errors: (Optional) Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to ENABLED and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to LEGACY, those APIs will return a UserNotFoundException exception if the user does not exist in the user pool.
+  ################################
+  prevent_user_existence_errors = try(each.value.prevent_user_existence_errors, null)
+
+  ##################
+  # read_attributes: (Optional) List of user pool attributes the application client can read from.
+  ##################
+  read_attributes = try(each.value.read_attributes, null)
+
+  #########################
+  # refresh_token_validity: (Optional) The time limit in days refresh tokens are valid for.
+  #########################
+  refresh_token_validity = try(each.value.refresh_token_validity, null)
+
+  ###############################
+  # supported_identity_providers: (Optional) List of provider names for the identity providers that are supported on this client.
+  ###############################
+  supported_identity_providers = try(each.value.supported_identity_providers, null)
+
+  ###################
+  # write_attributes: (Optional) List of user pool attributes the application client can write to.
+  ###################
+  write_attributes = try(each.value.write_attributes, null)
+
+  ###############
+  # user_pool_id: (Required) The user pool the client belongs to.
+  ###############
+  user_pool_id = aws_cognito_user_pool.pool.id
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -70,5 +70,8 @@ output "client_secret" {
 #
 output "resource_servers_scope_identifiers" {
   description = " A list of all scopes configured in the format identifier/scope_name"
-  value       = aws_cognito_resource_server.resource.*.scope_identifiers
+  value = {
+    for scope in aws_cognito_resource_server.resource :
+      scope.name => scope.scope_identifiers
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -49,14 +49,20 @@ output "domain_app_version" {
 #
 # aws_cognito_user_pool_client
 #
-output "client_ids" {
-  description = "The ids of the user pool clients"
-  value       = aws_cognito_user_pool_client.client.*.id
+output "client_id" {
+  description = "The ID of the user pool clients"
+  value = {
+    for client in aws_cognito_user_pool_client.client :
+      client.name => client.id
+  }
 }
 
-output "client_secrets" {
-  description = " The client secrets of the user pool clients"
-  value       = aws_cognito_user_pool_client.client.*.client_secret
+output "client_secret" {
+  description = "The client secret of the user pool clients"
+  value = {
+    for client in aws_cognito_user_pool_client.client :
+      client.name => client.client_secret
+  }
 }
 
 #

--- a/user-group.tf
+++ b/user-group.tf
@@ -1,32 +1,28 @@
 resource "aws_cognito_user_group" "main" {
-  count        = length(local.groups)
-  name         = lookup(element(local.groups, count.index), "name")
-  description  = lookup(element(local.groups, count.index), "description")
-  precedence   = lookup(element(local.groups, count.index), "precedence")
-  role_arn     = lookup(element(local.groups, count.index), "role_arn")
+  for_each = var.user_groups
+
+  #######
+  # name: The name of the user group. The resource will only be created when at least 1 name value has been defined.
+  #######
+  name = each.key
+
+  ##############
+  # description: (Optional) The description of the user group.
+  ##############
+  description = try(each.value.description, null)
+
+  #############
+  # precedence: (Optional) The precedence of the user group.
+  #############
+  precedence = try(each.value.precedence, null)
+
+  ###########
+  # role_arn: (Optional) The ARN of the IAM role to be associated with the user group.
+  ###########
+  role_arn = try(each.value.role_arn, null)
+
+  ###############
+  # user_pool_id: The user pool ID associated with this user_group.
+  ###############
   user_pool_id = aws_cognito_user_pool.pool.id
-}
-
-locals {
-  groups_default = [
-    {
-      name        = var.user_group_name
-      description = var.user_group_description
-      precedence  = var.user_group_precedence
-      role_arn    = var.user_group_role_arn
-
-    }
-  ]
-
-  # This parses var.user_groups which is a list of objects (map), and transforms it to a tuple of elements to avoid conflict with  the ternary and local.groups_default
-  groups_parsed = [for e in var.user_groups : {
-    name        = lookup(e, "name", null)
-    description = lookup(e, "description", null)
-    precedence  = lookup(e, "precedence", null)
-    role_arn    = lookup(e, "role_arn", null)
-    }
-  ]
-
-  groups = length(var.user_groups) == 0 && (var.user_group_name == null || var.user_group_name == "") ? [] : (length(var.user_groups) > 0 ? local.groups_parsed : local.groups_default)
-
 }

--- a/variables.tf
+++ b/variables.tf
@@ -469,33 +469,20 @@ variable "client_write_attributes" {
 # aws_cognito_user_group
 #
 variable "user_groups" {
-  description = "A container with the user_groups definitions"
-  type        = list
-  default     = []
-}
-
-variable "user_group_name" {
-  description = "The name of the user group"
-  type        = string
-  default     = null
-}
-
-variable "user_group_description" {
-  description = "The description of the user group"
-  type        = string
-  default     = null
-}
-
-variable "user_group_precedence" {
-  description = "The precedence of the user group"
-  type        = number
-  default     = null
-}
-
-variable "user_group_role_arn" {
-  description = "The ARN of the IAM role to be associated with the user group"
-  type        = string
-  default     = null
+  description = "Maps of objects containing the user_groups definitions. Refer to user-group.tf for the argument reference."
+  type        = map
+  default     = {}
+  ###Example:
+  ## user_groups = {
+  ##   "Group1" = {
+  ##     description = "Group1 description"
+  ##     precedence  = 40
+  ##     role_arn    = "arn:aws:iam::111111111111:role/group1_role"
+  ##   },
+  ##   "Group2" = {
+  ##     description = "Group2 description"
+  ##   },
+  ## }
 }
 
 #

--- a/variables.tf
+++ b/variables.tf
@@ -380,48 +380,48 @@ variable "clients" {
   type        = map
   default     = {}
 
-###Example:
-##  clients = {
-##    "test1" = {
-##      allowed_oauth_flows                  = ["code"]
-##      allowed_oauth_flows_user_pool_client = true
-##      allowed_oauth_scopes                 = []
-##      callback_urls                        = ["https://mydomain.com/callback"]
-##      default_redirect_uri                 = "https://mydomain.com/callback"
-##      explicit_auth_flows                  = [
-##        "ALLOW_USER_SRP_AUTH",
-##        "ALLOW_REFRESH_TOKEN_AUTH"
-##      ]
-##      generate_secret                      = false
-##      logout_urls                          = []
-##      prevent_user_existence_errors        = "ENABLED"
-##      read_attributes                      = [
-##        "email",
-##        "phone_number",
-##      ]
-##      refresh_token_validity               = 60
-##      supported_identity_providers         = []
-##      write_attributes                     = [
-##        "email",
-##        "gender",
-##        "locale",
-##      ]
-##    },
-##    "test2" = {
-##      allowed_oauth_flows                  = []
-##      allowed_oauth_flows_user_pool_client = false
-##      allowed_oauth_scopes                 = []
-##      callback_urls                        = ["https://mydomain.com/callback"]
-##      default_redirect_uri                 = "https://mydomain.com/callback"
-##      explicit_auth_flows                  = []
-##      generate_secret                      = false
-##      logout_urls                          = []
-##      read_attributes                      = []
-##      refresh_token_validity               = 30
-##      supported_identity_providers         = []
-##      write_attributes                     = []
-##    },
-##  }
+  ###Example:
+  ##  clients = {
+  ##    "test1" = {
+  ##      allowed_oauth_flows                  = ["code"]
+  ##      allowed_oauth_flows_user_pool_client = true
+  ##      allowed_oauth_scopes                 = []
+  ##      callback_urls                        = ["https://mydomain.com/callback"]
+  ##      default_redirect_uri                 = "https://mydomain.com/callback"
+  ##      explicit_auth_flows                  = [
+  ##        "ALLOW_USER_SRP_AUTH",
+  ##        "ALLOW_REFRESH_TOKEN_AUTH"
+  ##      ]
+  ##      generate_secret                      = false
+  ##      logout_urls                          = []
+  ##      prevent_user_existence_errors        = "ENABLED"
+  ##      read_attributes                      = [
+  ##        "email",
+  ##        "phone_number",
+  ##      ]
+  ##      refresh_token_validity               = 60
+  ##      supported_identity_providers         = []
+  ##      write_attributes                     = [
+  ##        "email",
+  ##        "gender",
+  ##        "locale",
+  ##      ]
+  ##    },
+  ##    "test2" = {
+  ##      allowed_oauth_flows                  = []
+  ##      allowed_oauth_flows_user_pool_client = false
+  ##      allowed_oauth_scopes                 = []
+  ##      callback_urls                        = ["https://mydomain.com/callback"]
+  ##      default_redirect_uri                 = "https://mydomain.com/callback"
+  ##      explicit_auth_flows                  = []
+  ##      generate_secret                      = false
+  ##      logout_urls                          = []
+  ##      read_attributes                      = []
+  ##      refresh_token_validity               = 30
+  ##      supported_identity_providers         = []
+  ##      write_attributes                     = []
+  ##    },
+  ##  }
 }
 
 #
@@ -449,9 +449,35 @@ variable "user_groups" {
 # aws_cognito_resource_server
 #
 variable "resource_servers" {
-  description = "A container with the user_groups definitions"
-  type        = list
-  default     = []
+  description = "Maps of objects containing the resource_servers definitions. Refer to resource-server.tf for argument reference."
+  type        = map
+  default     = {}
+
+  ###Example:
+  ## resource_servers = {
+  ##   "mydomain" = {
+  ##     identifier = "https://mydomain.com"
+  ##     scope      = [
+  ##       {
+  ##         scope_name        = "sample-scope-1"
+  ##         scope_description = "A sample Scope Description for mydomain.com"
+  ##       },
+  ##       {
+  ##         scope_name        = "sample-scope-2"
+  ##         scope_description = "Another sample Scope Description for mydomain.com"
+  ##       },
+  ##     ]
+  ##   },
+  ##   "weather-read" = {
+  ##     identifier = "https://weather-read-app.com"
+  ##     scope = [
+  ##       {
+  ##         scope_name        = "weather.read"
+  ##         scope_description = "Read weather forecasts"
+  ##       }
+  ##     ]
+  ##   }
+  ## }
 }
 
 variable "resource_server_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -376,93 +376,52 @@ variable "domain_certificate_arn" {
 # aws_cognito_user_pool_client
 #
 variable "clients" {
-  description = "A container with the clients definitions"
-  type        = list
-  default     = []
-}
+  description = "Maps of objects containing the clients definitions. Refer to client.tf for the argument reference."
+  type        = map
+  default     = {}
 
-variable "client_allowed_oauth_flows" {
-  description = "The name of the application client"
-  type        = list
-  default     = []
-}
-
-variable "client_allowed_oauth_flows_user_pool_client" {
-  description = "Whether the client is allowed to follow the OAuth protocol when interacting with Cognito user pools"
-  type        = bool
-  default     = true
-}
-
-variable "client_allowed_oauth_scopes" {
-  description = "List of allowed OAuth scopes (phone, email, openid, profile, and aws.cognito.signin.user.admin)"
-  type        = list
-  default     = []
-}
-
-variable "client_callback_urls" {
-  description = "List of allowed callback URLs for the identity providers"
-  type        = list
-  default     = []
-}
-
-variable "client_default_redirect_uri" {
-  description = "The default redirect URI. Must be in the list of callback URLs"
-  type        = string
-  default     = ""
-}
-
-variable "client_explicit_auth_flows" {
-  description = "List of authentication flows (ADMIN_NO_SRP_AUTH, CUSTOM_AUTH_FLOW_ONLY, USER_PASSWORD_AUTH)"
-  type        = list
-  default     = []
-}
-
-variable "client_generate_secret" {
-  description = "Should an application secret be generated"
-  type        = bool
-  default     = true
-}
-
-variable "client_logout_urls" {
-  description = "List of allowed logout URLs for the identity providers"
-  type        = list
-  default     = []
-}
-
-variable "client_name" {
-  description = "The name of the application client"
-  type        = string
-  default     = null
-}
-
-variable "client_read_attributes" {
-  description = "List of user pool attributes the application client can read from"
-  type        = list
-  default     = []
-}
-
-variable "client_refresh_token_validity" {
-  description = "The time limit in days refresh tokens are valid for"
-  type        = number
-  default     = 30
-}
-
-variable "client_prevent_user_existence_errors" {
-  description = "Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to ENABLED and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to LEGACY, those APIs will return a UserNotFoundException exception if the user does not exist in the user pool."
-  type        = string
-  default     = ""
-}
-
-variable "client_supported_identity_providers" {
-  description = "List of provider names for the identity providers that are supported on this client"
-  type        = list
-  default     = []
-}
-
-variable "client_write_attributes" {
-  description = "List of user pool attributes the application client can write to"
-  type        = list
-  default     = []
+###Example:
+##  clients = {
+##    "test1" = {
+##      allowed_oauth_flows                  = ["code"]
+##      allowed_oauth_flows_user_pool_client = true
+##      allowed_oauth_scopes                 = []
+##      callback_urls                        = ["https://mydomain.com/callback"]
+##      default_redirect_uri                 = "https://mydomain.com/callback"
+##      explicit_auth_flows                  = [
+##        "ALLOW_USER_SRP_AUTH",
+##        "ALLOW_REFRESH_TOKEN_AUTH"
+##      ]
+##      generate_secret                      = false
+##      logout_urls                          = []
+##      prevent_user_existence_errors        = "ENABLED"
+##      read_attributes                      = [
+##        "email",
+##        "phone_number",
+##      ]
+##      refresh_token_validity               = 60
+##      supported_identity_providers         = []
+##      write_attributes                     = [
+##        "email",
+##        "gender",
+##        "locale",
+##      ]
+##    },
+##    "test2" = {
+##      allowed_oauth_flows                  = []
+##      allowed_oauth_flows_user_pool_client = false
+##      allowed_oauth_scopes                 = []
+##      callback_urls                        = ["https://mydomain.com/callback"]
+##      default_redirect_uri                 = "https://mydomain.com/callback"
+##      explicit_auth_flows                  = []
+##      generate_secret                      = false
+##      logout_urls                          = []
+##      read_attributes                      = []
+##      refresh_token_validity               = 30
+##      supported_identity_providers         = []
+##      write_attributes                     = []
+##    },
+##  }
 }
 
 #
@@ -472,6 +431,7 @@ variable "user_groups" {
   description = "Maps of objects containing the user_groups definitions. Refer to user-group.tf for the argument reference."
   type        = map
   default     = {}
+
   ###Example:
   ## user_groups = {
   ##   "Group1" = {


### PR DESCRIPTION
When using count to manage these resource, the result of add/remove elements in the variable list may result in destroy and recreate of the resource, due to index change. This may not be a desirable for some user. Terraform 0.12.6 added ability the use of for_each at resource level to address this concern. This change replace the use of **count** with **for_each** in the following resources:

- aws_cognito_user_group
- aws_cognito_user_pool_client
- aws_cognito_resource_server

From Hashicorp 0.12 preview blog section "[Resource for_each](https://www.hashicorp.com/blog/hashicorp-terraform-0-12-preview-for-and-for-each/)"

> When the for_each argument value is a map, Terraform will identify each instance by the string key of the map element rather than by a numeric index, which will avoid many limitations with the current pattern of using count to iterate over a list where items may be added and removed from the middle of that list, changing the subsequent indices. 