### PR TITLE
Ignore schema changes and prevent pool destruction

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,6 +176,13 @@ resource "aws_cognito_user_pool" "pool" {
 
   # tags
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      schema,
+    ]
+    prevent_destroy = true
+  }
 }
 
 locals {


### PR DESCRIPTION
I'd consider this a temporary solution, until we get module lifecycle support in terraform and [#3891](https://github.com/hashicorp/terraform-provider-aws/issues/3891).
The latter is on the current [roadmap](https://github.com/hashicorp/terraform-provider-aws/blob/606ed39bfd0e13d2189000db084c5e0b1c7105c2/ROADMAP.md)

Basically it enables schema changes on the existing pool, without destroying it.
EDIT: To clarify, only aws console or cli support schema modifications currently..