### PR TITLE
set client_secrets output to be sensitive

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -57,6 +57,7 @@ output "client_ids" {
 output "client_secrets" {
   description = " The client secrets of the user pool clients"
   value       = var.enabled ? aws_cognito_user_pool_client.client.*.client_secret : null
+  sensitive   = true
 }
 
 #


### PR DESCRIPTION
Newer terraform version throws an error on applying the module since the client_secrets output variable must be marked as sensitive.