### PR TITLE
Add support for Cognito Identity Providers

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -245,6 +245,7 @@ module "aws_cognito_user_pool_complete_example" {
       attribute_mapping = {
         email    = "email"
         username = "sub"
+        gender   = "gender"
       }
     }
   ]

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -230,6 +230,25 @@ module "aws_cognito_user_pool_complete_example" {
     }
   ]
 
+  # identity_providers
+  identity_providers = [
+    {
+      provider_name = "Google"
+      provider_type = "Google"
+
+      provider_details = {
+        authorize_scopes = "email"
+        client_id        = "your client_id"
+        client_secret    = "your client_secret"
+      }
+
+      attribute_mapping = {
+        email    = "email"
+        username = "sub"
+      }
+    }
+  ]
+
   # tags
   tags = {
     Owner       = "infra"

--- a/identity-provider.tf
+++ b/identity-provider.tf
@@ -1,0 +1,11 @@
+resource "aws_cognito_identity_provider" "identity_provider" {
+  count         = var.enabled ? length(var.identity_providers) : 0
+  user_pool_id  = aws_cognito_user_pool.pool[0].id
+  provider_name = lookup(element(var.identity_providers, count.index), "provider_name")
+  provider_type = lookup(element(var.identity_providers, count.index), "provider_type")
+
+  # Optional arguments
+  attribute_mapping = lookup(element(var.identity_providers, count.index), "attribute_mapping", {})
+  idp_identifiers   = lookup(element(var.identity_providers, count.index), "idp_identifiers", [])
+  provider_details  = lookup(element(var.identity_providers, count.index), "provider_details", {})
+}

--- a/variables.tf
+++ b/variables.tf
@@ -574,3 +574,12 @@ variable "recovery_mechanisms" {
   type        = list(any)
   default     = []
 }
+
+#
+# aws_cognito_identity_provider
+#
+variable "identity_providers" {
+  description = "Cognito Pool Identity Providers"
+  type        = list(any)
+  default     = []
+}


### PR DESCRIPTION
This adds support for Cognito Identity Providers to the user pool. I have extended the complete example. I was able to deploy the example with Terraform successfully, with this addition. 