### PR TITLE
Fixes #68 Use accepted token validity periods

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -493,8 +493,8 @@ variable "client_token_validity_units" {
   description = "Configuration block for units in which the validity times are represented in. Valid values for the following arguments are: `seconds`, `minutes`, `hours` or `days`."
   type        = any
   default = {
-    access_token  = "hours"
-    id_token      = "hours"
+    access_token  = "minutes"
+    id_token      = "minutes"
     refresh_token = "days"
   }
 


### PR DESCRIPTION
The default values result in a access and id token validity period of 60
hours. Values are only accepted in the range 5 minutes to 1 day. I
suspect the original intention was to make this an hour.

Fixes #68 