### PR TITLE
Add identity provider as a dependency for aws_cognito_user_pool_client

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -28,7 +28,10 @@ resource "aws_cognito_user_pool_client" "client" {
     }
   }
 
-  depends_on = [aws_cognito_resource_server.resource]
+  depends_on = [
+    aws_cognito_resource_server.resource,
+    aws_cognito_identity_provider.identity_provider
+  ]
 }
 
 locals {


### PR DESCRIPTION
Fixes #71 

After trying this change locally, it never fails deployment again due to InvalidParameterException: The provider XXXXXX does not exist for User Pool YYYYYY