### PR TITLE
fix:  `client_prevent_user_existence_errors` default value is invalid

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -474,7 +474,7 @@ variable "client_read_attributes" {
 variable "client_prevent_user_existence_errors" {
   description = "Choose which errors and responses are returned by Cognito APIs during authentication, account confirmation, and password recovery when the user does not exist in the user pool. When set to ENABLED and the user does not exist, authentication returns an error indicating either the username or password was incorrect, and account confirmation and password recovery return a response indicating a code was sent to a simulated destination. When set to LEGACY, those APIs will return a UserNotFoundException exception if the user does not exist in the user pool."
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "client_supported_identity_providers" {


### PR DESCRIPTION
The default value for `client_prevent_user_existence_errors` is invalid. So not setting it (like in `examples/simple_extended`) ends in an error like this:

```
$ terraform apply
╷
│ Error: expected prevent_user_existence_errors to be one of [LEGACY ENABLED], got 
│ 
│   with module.aws_cognito_user_pool_simple_extended_example.aws_cognito_user_pool_client.client[0],
│   on .terraform/modules/aws_cognito_user_pool_simple_extended_example/client.tf line 17, in resource "aws_cognito_user_pool_client" "client":
│   17:   prevent_user_existence_errors        = lookup(element(local.clients, count.index), "prevent_user_existence_errors", null)
│ 
╵
```
