### PR TITLE
Feature/provider 4x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FIXES:
 
-* Change aws provider version contraints to be able to use 4.x
+* Change aws provider version constraints to be able to use 4.x
 
 ## 0.15.1 (February 15, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.2 (February 19, 2022)
+
+FIXES:
+
+* Change aws provider version contraints to be able to use 4.x
+
 ## 0.15.1 (February 15, 2022)
 
 FIXES:

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ module "aws_cognito_user_pool_complete" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 3.2 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.2 |
 
 ## Providers
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,9 @@ terraform {
   required_version = ">= 0.14.0"
 
   required_providers {
-    aws = "~> 3.2"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.2"
+    }
   }
 }


### PR DESCRIPTION
## 0.15.2 (February 19, 2022)

FIXES:

* Change aws provider version constraints to be able to use 4.x



It fixes #79 