### PR TITLE
feat: ignore estimated_number_of_users to have clear plan

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -209,10 +209,9 @@ resource "aws_cognito_user_pool" "pool" {
   # tags
   tags = var.tags
 
-  lifecycle {
-    ignore_changes = [
-      estimated_number_of_users
-    ]
+  lifecycle = {
+    prevent_destroy = var.is_prevent_destroy
+    ignore_changes  = var.ignore_changes_list
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -209,9 +209,10 @@ resource "aws_cognito_user_pool" "pool" {
   # tags
   tags = var.tags
 
-  lifecycle = {
-    prevent_destroy = var.is_prevent_destroy
-    ignore_changes  = var.ignore_changes_list
+  lifecycle {
+    ignore_changes = [
+      estimated_number_of_users
+    ]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -208,6 +208,12 @@ resource "aws_cognito_user_pool" "pool" {
 
   # tags
   tags = var.tags
+
+  lifecycle {
+    ignore_changes = [
+      estimated_number_of_users
+    ]
+  }
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -607,3 +607,17 @@ variable "identity_providers" {
   type        = list(any)
   default     = []
 }
+
+
+variable "ignore_changes_list" {
+  default     = ["estimated_number_of_users"]
+  description = "List of attribute changes to ignore in pool resource"
+  type        = list(string)
+
+}
+
+variable "is_prevent_destroy" {
+  default     = false
+  description = "Prevent destroy pool"
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -607,17 +607,3 @@ variable "identity_providers" {
   type        = list(any)
   default     = []
 }
-
-
-variable "ignore_changes_list" {
-  default     = ["estimated_number_of_users"]
-  description = "List of attribute changes to ignore in pool resource"
-  type        = list(string)
-
-}
-
-variable "is_prevent_destroy" {
-  default     = false
-  description = "Prevent destroy pool"
-  type        = bool
-}


### PR DESCRIPTION
When reviewing plan, I don't want to see estimated_number_of_users changing. This is more important when you have a lot of resource changes to review every day