### PR TITLE
fix the attributes constraints for number and string schemas

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -143,10 +143,10 @@ resource "aws_cognito_user_pool" "pool" {
 
       # string_attribute_constraints
       dynamic "string_attribute_constraints" {
-        for_each = length(lookup(schema.value, "string_attribute_constraints")) == 0 ? [] : [lookup(schema.value, "string_attribute_constraints", {})]
+        for_each = length(keys(lookup(schema.value, "string_attribute_constraints", {}))) == 0 ? [] : [lookup(schema.value, "string_attribute_constraints", {})]
         content {
-          min_length = lookup(string_attribute_constraints.value, "min_length", 0)
-          max_length = lookup(string_attribute_constraints.value, "max_length", 0)
+          min_length = lookup(string_attribute_constraints.value, "min_length", null)
+          max_length = lookup(string_attribute_constraints.value, "max_length", null)
         }
       }
     }
@@ -164,10 +164,10 @@ resource "aws_cognito_user_pool" "pool" {
 
       # number_attribute_constraints
       dynamic "number_attribute_constraints" {
-        for_each = length(lookup(schema.value, "number_attribute_constraints")) == 0 ? [] : [lookup(schema.value, "number_attribute_constraints", {})]
+        for_each = length(keys(lookup(schema.value, "number_attribute_constraints", {}))) == 0 ? [] : [lookup(schema.value, "number_attribute_constraints", {})]
         content {
-          min_value = lookup(number_attribute_constraints.value, "min_value", 0)
-          max_value = lookup(number_attribute_constraints.value, "max_value", 0)
+          min_value = lookup(number_attribute_constraints.value, "min_value", null)
+          max_value = lookup(number_attribute_constraints.value, "max_value", null)
         }
       }
     }


### PR DESCRIPTION
- `string_attribute_constraints` is `number_attribute_constraints` should be null or map so use `keys()` to dynamically decide to add values
- `min_value` and `max_value` are optional value so default to `null`