### PR TITLE
Remove duplicate `require_lowercase` key for password policies

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -271,7 +271,6 @@ variable "password_policy" {
   type = object({
     minimum_length                   = number,
     require_lowercase                = bool,
-    require_lowercase                = bool,
     require_numbers                  = bool,
     require_symbols                  = bool,
     require_uppercase                = bool,


### PR DESCRIPTION
Hey there 👋,

I noticed a duplicate `require_lowercase` key in the `password_policy` input variable. It doesn't hurt, but at least it's one line less to maintain 😊 

:octocat: 