### PR TITLE
Set `identity_providers` variable to sensitive

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -612,4 +612,5 @@ variable "identity_providers" {
   description = "Cognito Pool Identity Providers"
   type        = list(any)
   default     = []
+  sensitive   = true
 }


### PR DESCRIPTION
## What
Set the variaable `identity_providers` to `sensitive = true`.
## Why
The information in this variable, especially `client_secret`, could be sensitive.