### PR TITLE
Fix user attribute update settings lookup

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,7 @@ resource "aws_cognito_user_pool" "pool" {
   }
 
   dynamic "user_attribute_update_settings" {
-    for_each = [local.user_attribute_update_settings]
+    for_each = local.user_attribute_update_settings
     content {
       attributes_require_verification_before_update = lookup(user_attribute_update_settings.value, "attributes_require_verification_before_update")
     }
@@ -321,5 +321,5 @@ locals {
 
   # user_attribute_update_settings
   # As default, all auto_verified_attributes will become attributes_require_verification_before_update
-  user_attribute_update_settings = var.user_attribute_update_settings == null ? (length(var.auto_verified_attributes) > 0 ? { attributes_require_verification_before_update = var.auto_verified_attributes } : {}) : var.user_attribute_update_settings
+  user_attribute_update_settings = var.user_attribute_update_settings == null ? (length(var.auto_verified_attributes) > 0 ? [{ attributes_require_verification_before_update = var.auto_verified_attributes }] : []) : [var.user_attribute_update_settings]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -362,8 +362,8 @@ variable "tags" {
 
 # user_attribute_update_settings
 variable "user_attribute_update_settings" {
-  description = "Configuration block for user attribute update settings"
-  type        = map(any)
+  description = "Configuration block for user attribute update settings. Must contain key `attributes_require_verification_before_update` with list with only valid values of `email` and `phone_number`"
+  type        = map(list(string))
   default     = null
 }
 


### PR DESCRIPTION
Change to fix https://github.com/lgallard/terraform-aws-cognito-user-pool/issues/112. Issue was still looping when `user_attribute_update_settings` was `null` due to list still having an empty map inside it.