### PR TITLE
Add cloudfront_distribution_zone_id in output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -36,6 +36,11 @@ output "domain_cloudfront_distribution_arn" {
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution_arn) : null
 }
 
+output "domain_cloudfront_distribution_zone_id" {
+  description = "The ARN of the CloudFront distribution"
+  value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution_zone_id) : null
+}
+
 output "domain_s3_bucket" {
   description = "The S3 bucket where the static files for this domain are stored"
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.s3_bucket) : null


### PR DESCRIPTION
This parameter is requested to add the the A Record with the cloudfront distribution as alias.
Source:
https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain#cloudfront_distribution_zone_id