### PR TITLE
Removing device configuration config where challenge_required_on_new_…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -254,7 +254,7 @@ locals {
     device_only_remembered_on_user_prompt = lookup(var.device_configuration, "device_only_remembered_on_user_prompt", null) == null ? var.device_configuration_device_only_remembered_on_user_prompt : lookup(var.device_configuration, "device_only_remembered_on_user_prompt")
   }
 
-  device_configuration = lookup(local.device_configuration_default, "challenge_required_on_new_device") == false && lookup(local.device_configuration_default, "device_only_remembered_on_user_prompt") == false ? [] : [local.device_configuration_default]
+  device_configuration = [local.device_configuration_default]
 
   # email_configuration
   # If no email_configuration is provided, build a email_configuration using the default values

--- a/main.tf
+++ b/main.tf
@@ -249,12 +249,10 @@ locals {
 
   # device_configuration
   # If no device_configuration list is provided, build a device_configuration using the default values
-  device_configuration_default = {
+  device_configuration = [{
     challenge_required_on_new_device      = lookup(var.device_configuration, "challenge_required_on_new_device", null) == null ? var.device_configuration_challenge_required_on_new_device : lookup(var.device_configuration, "challenge_required_on_new_device")
     device_only_remembered_on_user_prompt = lookup(var.device_configuration, "device_only_remembered_on_user_prompt", null) == null ? var.device_configuration_device_only_remembered_on_user_prompt : lookup(var.device_configuration, "device_only_remembered_on_user_prompt")
-  }
-
-  device_configuration = [local.device_configuration_default]
+  }]
 
   # email_configuration
   # If no email_configuration is provided, build a email_configuration using the default values

--- a/variables.tf
+++ b/variables.tf
@@ -122,13 +122,13 @@ variable "device_configuration" {
 variable "device_configuration_challenge_required_on_new_device" {
   description = "Indicates whether a challenge is required on a new device. Only applicable to a new device"
   type        = bool
-  default     = false
+  default     = null
 }
 
 variable "device_configuration_device_only_remembered_on_user_prompt" {
   description = "If true, a device is only remembered on user prompt"
   type        = bool
-  default     = false
+  default     = null
 }
 
 # email_configuration


### PR DESCRIPTION
…device and device_only_remembered_on_user_prompt cannot both be false.

PR to help resolve issue https://github.com/lgallard/terraform-aws-cognito-user-pool/issues/122