### PR TITLE
Update main.tf

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,13 @@ resource "aws_cognito_user_pool" "pool" {
 
   # tags
   tags = var.tags
+  
+  lifecycle {
+    ignore_changes = [
+      schema,
+    ]
+    prevent_destroy = true
+  }
 }
 
 locals {


### PR DESCRIPTION
This PR reintroduces the previously removed lifecyle ignore block. 

As described in https://github.com/lgallard/terraform-aws-cognito-user-pool/issues/125 , the underlying issue is still present. I'm not sure if its an upstream issue in the Hashicorp package or not, but at least as interim solution, its worth bringing this block back. Without it, we are unable to deploy any changes via this module. 

I've tested the fork against our config and appears to work correctly. 

The error shown is:

```sh
│ Error: updating Cognito User Pool (): cannot modify or remove schema items
│
│   with module.application.module.delivery_layer.module.cognito.module.cognito.aws_cognito_user_pool.pool[0],
│   on .terraform/modules/application.delivery_layer.cognito.cognito/main.tf line 1, in resource "aws_cognito_user_pool" "pool":
│    1: resource "aws_cognito_user_pool" "pool" {
```

With the relevant chunk of the plan:

```sh
      - schema {
          - attribute_data_type      = "Number" -> null
          - developer_only_attribute = false -> null
          - mutable                  = true -> null
          - name                     = "push_notifications" -> null
          - required                 = false -> null

          - number_attribute_constraints {}
        }
      + schema {
          + attribute_data_type      = "Number"
          + developer_only_attribute = false
          + mutable                  = true
          + name                     = "push_notifications"
          + required                 = false
        }
```

We've also attempted to explicitly set the constraints with:

```
      number_attribute_constraints = {}
```

And...

```
      number_attribute_constraints = {
        min_length = 0
        max_length = 2048  
      }
```

But that is ignored 