### PR TITLE
Add back previously removed lifecyle ignore block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.25.0 (February 17, 2024)
+
+FIXES:
+
+* Add back previously removed lifecyle ignore block (thanks @chris-symbiote)
+
 ## 0.24.0 (November 13, 2023)
 
 FIXES:

--- a/main.tf
+++ b/main.tf
@@ -216,13 +216,6 @@ resource "aws_cognito_user_pool" "pool" {
 
   # tags
   tags = var.tags
-  
-  lifecycle {
-    ignore_changes = [
-      schema,
-    ]
-    prevent_destroy = true
-  }
 }
 
 locals {


### PR DESCRIPTION
## 0.25.0 (February 17, 2024)

FIXES:

* Add back previously removed lifecyle ignore block (thanks @chris-symbiote)