### PR TITLE
Add support for pre token customization lambda V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.27.0 (April 22, 2024)
+
+ENHANCEMENTS:
+
+* Add `cloudfront_distribution_zone_id` attribute as output (thanks @catrielg)
+
+FIXES:
+
+* Fix support for pre token customization lambda V2 (thanks @Dogacel)
+
 ## 0.26.0 (March 22, 2024)
 
 ENHANCEMENTS:

--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ No modules.
 | <a name="output_domain_app_version"></a> [domain\_app\_version](#output\_domain\_app\_version) | The app version |
 | <a name="output_domain_aws_account_id"></a> [domain\_aws\_account\_id](#output\_domain\_aws\_account\_id) | The AWS account ID for the user pool owner |
 | <a name="output_domain_cloudfront_distribution_arn"></a> [domain\_cloudfront\_distribution\_arn](#output\_domain\_cloudfront\_distribution\_arn) | The ARN of the CloudFront distribution |
+| <a name="output_domain_cloudfront_distribution_zone_id"></a> [domain\_cloudfront\_distribution\_zone\_id](#output\_domain\_cloudfront\_distribution\_zone\_id) | The ZoneID of the CloudFront distribution |
 | <a name="output_domain_s3_bucket"></a> [domain\_s3\_bucket](#output\_domain\_s3\_bucket) | The S3 bucket where the static files for this domain are stored |
 | <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | The endpoint name of the user pool. Example format: cognito-idp.REGION.amazonaws.com/xxxx\_yyyyy |
 | <a name="output_id"></a> [id](#output\_id) | The id of the user pool |

--- a/outputs.tf
+++ b/outputs.tf
@@ -41,6 +41,11 @@ output "domain_cloudfront_distribution_arn" {
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution_arn) : null
 }
 
+output "domain_cloudfront_distribution_zone_id" {
+  description = "The ZoneID of the CloudFront distribution"
+  value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution_zone_id) : null
+}
+
 output "domain_s3_bucket" {
   description = "The S3 bucket where the static files for this domain are stored"
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.s3_bucket) : null


### PR DESCRIPTION
## 0.27.0 (April 22, 2024)

ENHANCEMENTS:

* Add `cloudfront_distribution_zone_id` attribute as output (thanks @catrielg)

FIXES:

* Fix support for pre token customization lambda V2 (thanks @Dogacel)