### PR TITLE
fix: lambda customization config not working

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,10 +71,10 @@ resource "aws_cognito_user_pool" "pool" {
       pre_sign_up           = lookup(var.lambda_config, "pre_sign_up", var.lambda_config_pre_sign_up)
       pre_token_generation  = lookup(var.lambda_config, "pre_token_generation", var.lambda_config_pre_token_generation)
       dynamic "pre_token_generation_config" {
-        for_each = lookup(var.lambda_config, "pre_token_generation_config", null) != null ? [lookup(var.lambda_config, "pre_token_generation_config", {})] : []
+        for_each = lookup(var.lambda_config, "pre_token_generation_config", null) == null ? [] : [1]
         content {
-          lambda_arn     = lookup(for_each.value, "lambda_arn", null)
-          lambda_version = lookup(for_each.value, "lambda_version", null)
+          lambda_arn     = lookup(lookup(var.lambda_config, "pre_token_generation_config", {}), "lambda_arn", null)
+          lambda_version = lookup(lookup(var.lambda_config, "pre_token_generation_config", {}), "lambda_version", null)
         }
       }
       user_migration                 = lookup(var.lambda_config, "user_migration", var.lambda_config_user_migration)


### PR DESCRIPTION
The error I was getting:

```
│ Error: Reference to undeclared resource
│
│   on .terraform/modules/cognito_user_pool/main.tf line 76, in resource "aws_cognito_user_pool" "pool":
│   76:           lambda_arn     = lookup(for_each.value, "lambda_arn", null)
│
│ A managed resource "for_each" "value" has not been declared in
│ module.cognito_user_pool.
╵
```

So I decided to test a couple things, `each.value`, `each.key` etc. but none of them worked. 

```
│ A reference to "each.value" has been used in a context in which it
│ unavailable, such as when the configuration no longer contains the value in
│ its "for_each" expression. Remove this reference to each.value in your
│ configuration to work around this error.
```

So I just decided to make it consistent with other lambda blocks by copy-pasting the lookup blocks 🙂.


This has been tested in my local.

@lgallard Here is a final fix, sorry I was unavailable yesterday most of the time.