### PR TITLE
Add domain cloudfront_distribution name attribute as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -36,6 +36,11 @@ output "domain_aws_account_id" {
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.aws_account_id) : null
 }
 
+output "domain_cloudfront_distribution" {
+  description = "The name of the CloudFront distribution"
+  value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution) : null
+}
+
 output "domain_cloudfront_distribution_arn" {
   description = "The ARN of the CloudFront distribution"
   value       = var.enabled ? join("", aws_cognito_user_pool_domain.domain.*.cloudfront_distribution_arn) : null


### PR DESCRIPTION
This change enables to expose the domain name associated to the generated CloudFront distribution.
For IaC scenarions, it is mandatory in order to generate a custom CNAME record pointing to that distribution.

@lgallard This is the same change you introduced in 63e5ec8 but for the CloudFront domain name.
