### PR TITLE
Feat/password history size

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ module "aws_cognito_user_pool_complete" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.66 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.73 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.66.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.73.0 |
 
 ## Modules
 
@@ -229,6 +229,7 @@ No modules.
 | <a name="input_lambda_config_verify_auth_challenge_response"></a> [lambda\_config\_verify\_auth\_challenge\_response](#input\_lambda\_config\_verify\_auth\_challenge\_response) | Verifies the authentication challenge response | `string` | `null` | no |
 | <a name="input_mfa_configuration"></a> [mfa\_configuration](#input\_mfa\_configuration) | Set to enable multi-factor authentication. Must be one of the following values (ON, OFF, OPTIONAL) | `string` | `"OFF"` | no |
 | <a name="input_number_schemas"></a> [number\_schemas](#input\_number\_schemas) | A container with the number schema attributes of a user pool. Maximum of 50 attributes | `list(any)` | `[]` | no |
+| <a name="input_password_history_size"></a> [password\_history\_size](#input\_password\_history\_size) | The number of previous passwords that users are prevented from reusing | `number` | `0` | no |
 | <a name="input_password_policy"></a> [password\_policy](#input\_password\_policy) | A container for information about the user pool password policy | <pre>object({<br>    minimum_length                   = number,<br>    require_lowercase                = bool,<br>    require_numbers                  = bool,<br>    require_symbols                  = bool,<br>    require_uppercase                = bool,<br>    temporary_password_validity_days = number<br>    password_history_size            = number<br>  })</pre> | `null` | no |
 | <a name="input_password_policy_minimum_length"></a> [password\_policy\_minimum\_length](#input\_password\_policy\_minimum\_length) | The minimum length of the password policy that you have set | `number` | `8` | no |
 | <a name="input_password_policy_require_lowercase"></a> [password\_policy\_require\_lowercase](#input\_password\_policy\_require\_lowercase) | Whether you have required users to use at least one lowercase letter in their password | `bool` | `true` | no |

--- a/README.md
+++ b/README.md
@@ -141,13 +141,13 @@ module "aws_cognito_user_pool_complete" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= v0.13.7 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.66 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.42.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.66.0 |
 
 ## Modules
 
@@ -229,7 +229,7 @@ No modules.
 | <a name="input_lambda_config_verify_auth_challenge_response"></a> [lambda\_config\_verify\_auth\_challenge\_response](#input\_lambda\_config\_verify\_auth\_challenge\_response) | Verifies the authentication challenge response | `string` | `null` | no |
 | <a name="input_mfa_configuration"></a> [mfa\_configuration](#input\_mfa\_configuration) | Set to enable multi-factor authentication. Must be one of the following values (ON, OFF, OPTIONAL) | `string` | `"OFF"` | no |
 | <a name="input_number_schemas"></a> [number\_schemas](#input\_number\_schemas) | A container with the number schema attributes of a user pool. Maximum of 50 attributes | `list(any)` | `[]` | no |
-| <a name="input_password_policy"></a> [password\_policy](#input\_password\_policy) | A container for information about the user pool password policy | <pre>object({<br>    minimum_length                   = number,<br>    require_lowercase                = bool,<br>    require_numbers                  = bool,<br>    require_symbols                  = bool,<br>    require_uppercase                = bool,<br>    temporary_password_validity_days = number<br>  })</pre> | `null` | no |
+| <a name="input_password_policy"></a> [password\_policy](#input\_password\_policy) | A container for information about the user pool password policy | <pre>object({<br>    minimum_length                   = number,<br>    require_lowercase                = bool,<br>    require_numbers                  = bool,<br>    require_symbols                  = bool,<br>    require_uppercase                = bool,<br>    temporary_password_validity_days = number<br>    password_history_size            = number<br>  })</pre> | `null` | no |
 | <a name="input_password_policy_minimum_length"></a> [password\_policy\_minimum\_length](#input\_password\_policy\_minimum\_length) | The minimum length of the password policy that you have set | `number` | `8` | no |
 | <a name="input_password_policy_require_lowercase"></a> [password\_policy\_require\_lowercase](#input\_password\_policy\_require\_lowercase) | Whether you have required users to use at least one lowercase letter in their password | `bool` | `true` | no |
 | <a name="input_password_policy_require_numbers"></a> [password\_policy\_require\_numbers](#input\_password\_policy\_require\_numbers) | Whether you have required users to use at least one number in their password | `bool` | `true` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -65,7 +65,7 @@ module "aws_cognito_user_pool_complete_example" {
     require_symbols                  = true
     require_uppercase                = true
     temporary_password_validity_days = 120
-
+    password_history_size            = 5
   }
 
   user_pool_add_ons = {

--- a/main.tf
+++ b/main.tf
@@ -309,6 +309,7 @@ locals {
     require_symbols                  = var.password_policy_require_symbols
     require_uppercase                = var.password_policy_require_uppercase
     temporary_password_validity_days = var.password_policy_temporary_password_validity_days
+    password_history_size            = var.password_policy_password_history_size
   }
 
   password_policy_not_null = var.password_policy == null ? local.password_policy_is_null : {
@@ -318,7 +319,7 @@ locals {
     require_symbols                  = lookup(var.password_policy, "require_symbols", null) == null ? var.password_policy_require_symbols : lookup(var.password_policy, "require_symbols")
     require_uppercase                = lookup(var.password_policy, "require_uppercase", null) == null ? var.password_policy_require_uppercase : lookup(var.password_policy, "require_uppercase")
     temporary_password_validity_days = lookup(var.password_policy, "temporary_password_validity_days", null) == null ? var.password_policy_temporary_password_validity_days : lookup(var.password_policy, "temporary_password_validity_days")
-
+    password_history_size            = lookup(var.password_policy, "password_history_size", null) == null ? var.password_policy_password_history_size : lookup(var.password_policy, "password_history_size")
   }
 
   # Return the default values

--- a/main.tf
+++ b/main.tf
@@ -124,6 +124,7 @@ resource "aws_cognito_user_pool" "pool" {
       require_symbols                  = lookup(password_policy.value, "require_symbols")
       require_uppercase                = lookup(password_policy.value, "require_uppercase")
       temporary_password_validity_days = lookup(password_policy.value, "temporary_password_validity_days")
+      password_history_size            = lookup(password_policy.value, "password_history_size")
     }
   }
 

--- a/variables.tf
+++ b/variables.tf
@@ -287,6 +287,7 @@ variable "password_policy" {
     require_symbols                  = bool,
     require_uppercase                = bool,
     temporary_password_validity_days = number
+    password_history_size            = number
   })
   default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -328,6 +328,12 @@ variable "password_policy_temporary_password_validity_days" {
   default     = 7
 }
 
+variable "password_history_size" {
+  description = "The number of previous passwords that users are prevented from reusing"
+  type        = number
+  default     = 0
+}
+
 # schema
 variable "schemas" {
   description = "A container with the schema attributes of a user pool. Maximum of 50 attributes"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38"
+      version = ">= 5.73"
     }
   }
 }


### PR DESCRIPTION
This pull request includes several updates to the AWS Cognito User Pool module. The key changes involve updating the AWS provider version and enhancing the password policy configuration to include a password history size parameter.

### Version Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L144-R150): Updated the AWS provider version requirement to `>= 5.73`.
* [`versions.tf`](diffhunk://#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927L7-R7): Updated the AWS provider version to `>= 5.73`.

### Password Policy Enhancements:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L232-R233): Added `password_history_size` to the password policy configuration and updated the documentation accordingly.
* [`examples/complete/main.tf`](diffhunk://#diff-07f337e38ed1996f30ee4f04357ab23318c254cb606aaf4745d564cbd546722dL68-R68): Included `password_history_size` in the example configuration.
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR127): Added `password_history_size` to the `aws_cognito_user_pool` resource and updated local variables to support this new parameter. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR127) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR312) [[3]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL320-R322)
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR290): Introduced a new variable `password_history_size` and updated the `password_policy` variable to include this parameter. [[1]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR290) [[2]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR331-R336)