### PR TITLE
Feature/enable propagate additional user context data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.32.0 (Oct 27, 2024)
+
+ENHANCEMENTS:
+
+* Add enable_propagate_additional_user_context_data (thanks @AzgadGZ-CH)
+
+FIXES:
+
+* Fix device_configuration perpetual in-place replacement (thanks @joelgaria)
+* Added comment in the complete example regarding perpetual in-place replacements when using sensitive data in idnetity_provider resources
+
 ## 0.31.0 (Aug 09, 2024)
 
 FIXES:

--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ No modules.
 | <a name="input_email_configuration_source_arn"></a> [email\_configuration\_source\_arn](#input\_email\_configuration\_source\_arn) | The ARN of the email source | `string` | `""` | no |
 | <a name="input_email_verification_message"></a> [email\_verification\_message](#input\_email\_verification\_message) | A string representing the email verification message | `string` | `null` | no |
 | <a name="input_email_verification_subject"></a> [email\_verification\_subject](#input\_email\_verification\_subject) | A string representing the email verification subject | `string` | `null` | no |
+| <a name="input_enable_propagate_additional_user_context_data"></a> [enable\_propagate\_additional\_user\_context\_data](#input\_enable\_propagate\_additional\_user\_context\_data) | Enables the propagation of additional user context data | `bool` | `false` | no |
 | <a name="input_enabled"></a> [enabled](#input\_enabled) | Change to false to avoid deploying any resources | `bool` | `true` | no |
 | <a name="input_identity_providers"></a> [identity\_providers](#input\_identity\_providers) | Cognito Pool Identity Providers | `list(any)` | `[]` | no |
 | <a name="input_lambda_config"></a> [lambda\_config](#input\_lambda\_config) | A container for the AWS Lambda triggers associated with the user pool | `any` | `{}` | no |

--- a/client.tf
+++ b/client.tf
@@ -1,24 +1,25 @@
 resource "aws_cognito_user_pool_client" "client" {
-  count                                = var.enabled ? length(local.clients) : 0
-  allowed_oauth_flows                  = lookup(element(local.clients, count.index), "allowed_oauth_flows", null)
-  allowed_oauth_flows_user_pool_client = lookup(element(local.clients, count.index), "allowed_oauth_flows_user_pool_client", null)
-  allowed_oauth_scopes                 = lookup(element(local.clients, count.index), "allowed_oauth_scopes", null)
-  auth_session_validity                = lookup(element(local.clients, count.index), "auth_session_validity", null)
-  callback_urls                        = lookup(element(local.clients, count.index), "callback_urls", null)
-  default_redirect_uri                 = lookup(element(local.clients, count.index), "default_redirect_uri", null)
-  explicit_auth_flows                  = lookup(element(local.clients, count.index), "explicit_auth_flows", null)
-  generate_secret                      = lookup(element(local.clients, count.index), "generate_secret", null)
-  logout_urls                          = lookup(element(local.clients, count.index), "logout_urls", null)
-  name                                 = lookup(element(local.clients, count.index), "name", null)
-  read_attributes                      = lookup(element(local.clients, count.index), "read_attributes", null)
-  access_token_validity                = lookup(element(local.clients, count.index), "access_token_validity", null)
-  id_token_validity                    = lookup(element(local.clients, count.index), "id_token_validity", null)
-  refresh_token_validity               = lookup(element(local.clients, count.index), "refresh_token_validity", null)
-  supported_identity_providers         = lookup(element(local.clients, count.index), "supported_identity_providers", null)
-  prevent_user_existence_errors        = lookup(element(local.clients, count.index), "prevent_user_existence_errors", null)
-  write_attributes                     = lookup(element(local.clients, count.index), "write_attributes", null)
-  enable_token_revocation              = lookup(element(local.clients, count.index), "enable_token_revocation", null)
-  user_pool_id                         = aws_cognito_user_pool.pool[0].id
+  count                                         = var.enabled ? length(local.clients) : 0
+  allowed_oauth_flows                           = lookup(element(local.clients, count.index), "allowed_oauth_flows", null)
+  allowed_oauth_flows_user_pool_client          = lookup(element(local.clients, count.index), "allowed_oauth_flows_user_pool_client", null)
+  allowed_oauth_scopes                          = lookup(element(local.clients, count.index), "allowed_oauth_scopes", null)
+  auth_session_validity                         = lookup(element(local.clients, count.index), "auth_session_validity", null)
+  callback_urls                                 = lookup(element(local.clients, count.index), "callback_urls", null)
+  default_redirect_uri                          = lookup(element(local.clients, count.index), "default_redirect_uri", null)
+  explicit_auth_flows                           = lookup(element(local.clients, count.index), "explicit_auth_flows", null)
+  generate_secret                               = lookup(element(local.clients, count.index), "generate_secret", null)
+  logout_urls                                   = lookup(element(local.clients, count.index), "logout_urls", null)
+  name                                          = lookup(element(local.clients, count.index), "name", null)
+  read_attributes                               = lookup(element(local.clients, count.index), "read_attributes", null)
+  access_token_validity                         = lookup(element(local.clients, count.index), "access_token_validity", null)
+  id_token_validity                             = lookup(element(local.clients, count.index), "id_token_validity", null)
+  refresh_token_validity                        = lookup(element(local.clients, count.index), "refresh_token_validity", null)
+  supported_identity_providers                  = lookup(element(local.clients, count.index), "supported_identity_providers", null)
+  enable_propagate_additional_user_context_data = lookup(element(local.clients, count.index), "enable_propagate_additional_user_context_data", null)
+  prevent_user_existence_errors                 = lookup(element(local.clients, count.index), "prevent_user_existence_errors", null)
+  write_attributes                              = lookup(element(local.clients, count.index), "write_attributes", null)
+  enable_token_revocation                       = lookup(element(local.clients, count.index), "enable_token_revocation", null)
+  user_pool_id                                  = aws_cognito_user_pool.pool[0].id
 
   # token_validity_units
   dynamic "token_validity_units" {
@@ -39,49 +40,51 @@ resource "aws_cognito_user_pool_client" "client" {
 locals {
   clients_default = [
     {
-      allowed_oauth_flows                  = var.client_allowed_oauth_flows
-      allowed_oauth_flows_user_pool_client = var.client_allowed_oauth_flows_user_pool_client
-      allowed_oauth_scopes                 = var.client_allowed_oauth_scopes
-      auth_session_validity                = var.client_auth_session_validity
-      callback_urls                        = var.client_callback_urls
-      default_redirect_uri                 = var.client_default_redirect_uri
-      explicit_auth_flows                  = var.client_explicit_auth_flows
-      generate_secret                      = var.client_generate_secret
-      logout_urls                          = var.client_logout_urls
-      name                                 = var.client_name
-      read_attributes                      = var.client_read_attributes
-      access_token_validity                = var.client_access_token_validity
-      id_token_validity                    = var.client_id_token_validity
-      token_validity_units                 = var.client_token_validity_units
-      refresh_token_validity               = var.client_refresh_token_validity
-      supported_identity_providers         = var.client_supported_identity_providers
-      prevent_user_existence_errors        = var.client_prevent_user_existence_errors
-      write_attributes                     = var.client_write_attributes
-      enable_token_revocation              = var.client_enable_token_revocation
+      allowed_oauth_flows                           = var.client_allowed_oauth_flows
+      allowed_oauth_flows_user_pool_client          = var.client_allowed_oauth_flows_user_pool_client
+      allowed_oauth_scopes                          = var.client_allowed_oauth_scopes
+      auth_session_validity                         = var.client_auth_session_validity
+      callback_urls                                 = var.client_callback_urls
+      default_redirect_uri                          = var.client_default_redirect_uri
+      explicit_auth_flows                           = var.client_explicit_auth_flows
+      generate_secret                               = var.client_generate_secret
+      logout_urls                                   = var.client_logout_urls
+      name                                          = var.client_name
+      read_attributes                               = var.client_read_attributes
+      access_token_validity                         = var.client_access_token_validity
+      id_token_validity                             = var.client_id_token_validity
+      token_validity_units                          = var.client_token_validity_units
+      refresh_token_validity                        = var.client_refresh_token_validity
+      enable_propagate_additional_user_context_data = var.enable_propagate_additional_user_context_data
+      supported_identity_providers                  = var.client_supported_identity_providers
+      prevent_user_existence_errors                 = var.client_prevent_user_existence_errors
+      write_attributes                              = var.client_write_attributes
+      enable_token_revocation                       = var.client_enable_token_revocation
     }
   ]
 
   # This parses vars.clients which is a list of objects (map), and transforms it to a tuple of elements to avoid conflict with  the ternary and local.clients_default
   clients_parsed = [for e in var.clients : {
-    allowed_oauth_flows                  = lookup(e, "allowed_oauth_flows", null)
-    allowed_oauth_flows_user_pool_client = lookup(e, "allowed_oauth_flows_user_pool_client", null)
-    allowed_oauth_scopes                 = lookup(e, "allowed_oauth_scopes", null)
-    auth_session_validity                = lookup(e, "auth_session_validity", null)
-    callback_urls                        = lookup(e, "callback_urls", null)
-    default_redirect_uri                 = lookup(e, "default_redirect_uri", null)
-    explicit_auth_flows                  = lookup(e, "explicit_auth_flows", null)
-    generate_secret                      = lookup(e, "generate_secret", null)
-    logout_urls                          = lookup(e, "logout_urls", null)
-    name                                 = lookup(e, "name", null)
-    read_attributes                      = lookup(e, "read_attributes", null)
-    access_token_validity                = lookup(e, "access_token_validity", null)
-    id_token_validity                    = lookup(e, "id_token_validity", null)
-    refresh_token_validity               = lookup(e, "refresh_token_validity", null)
-    token_validity_units                 = lookup(e, "token_validity_units", {})
-    supported_identity_providers         = lookup(e, "supported_identity_providers", null)
-    prevent_user_existence_errors        = lookup(e, "prevent_user_existence_errors", null)
-    write_attributes                     = lookup(e, "write_attributes", null)
-    enable_token_revocation              = lookup(e, "enable_token_revocation", null)
+    allowed_oauth_flows                           = lookup(e, "allowed_oauth_flows", null)
+    allowed_oauth_flows_user_pool_client          = lookup(e, "allowed_oauth_flows_user_pool_client", null)
+    allowed_oauth_scopes                          = lookup(e, "allowed_oauth_scopes", null)
+    auth_session_validity                         = lookup(e, "auth_session_validity", null)
+    callback_urls                                 = lookup(e, "callback_urls", null)
+    default_redirect_uri                          = lookup(e, "default_redirect_uri", null)
+    explicit_auth_flows                           = lookup(e, "explicit_auth_flows", null)
+    generate_secret                               = lookup(e, "generate_secret", null)
+    logout_urls                                   = lookup(e, "logout_urls", null)
+    name                                          = lookup(e, "name", null)
+    read_attributes                               = lookup(e, "read_attributes", null)
+    access_token_validity                         = lookup(e, "access_token_validity", null)
+    id_token_validity                             = lookup(e, "id_token_validity", null)
+    refresh_token_validity                        = lookup(e, "refresh_token_validity", null)
+    enable_propagate_additional_user_context_data = lookup(e, "enable_propagate_additional_user_context_data", null)
+    token_validity_units                          = lookup(e, "token_validity_units", {})
+    supported_identity_providers                  = lookup(e, "supported_identity_providers", null)
+    prevent_user_existence_errors                 = lookup(e, "prevent_user_existence_errors", null)
+    write_attributes                              = lookup(e, "write_attributes", null)
+    enable_token_revocation                       = lookup(e, "enable_token_revocation", null)
     }
   ]
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -254,8 +254,8 @@ module "aws_cognito_user_pool_complete_example" {
 
       provider_details = {
         authorize_scopes              = "email"
-        client_id                     = "your client_id"
-        client_secret                 = "your client_secret"
+        client_id                     = "your client_id"     # This should be retrieved from AWS Secret Manager, otherwise Terraform will force an in-place replacement becuase is treated as a sensitive value
+        client_secret                 = "your client_secret" # # This should be retrieved from AWS Secret Manager, otherwise Terraform will force an in-place replacement becuase is treated as a sensitive value
         attributes_url_add_attributes = "true"
         authorize_url                 = "https://accounts.google.com/o/oauth2/v2/auth"
         oidc_issuer                   = "https://accounts.google.com"

--- a/main.tf
+++ b/main.tf
@@ -260,7 +260,8 @@ locals {
 
   # device_configuration
   # If no device_configuration list is provided, build a device_configuration using the default values
-  device_configuration = [{
+
+  device_configuration = length(var.device_configuration) == 0 ? [] : [{
     challenge_required_on_new_device      = lookup(var.device_configuration, "challenge_required_on_new_device", null) == null ? var.device_configuration_challenge_required_on_new_device : lookup(var.device_configuration, "challenge_required_on_new_device")
     device_only_remembered_on_user_prompt = lookup(var.device_configuration, "device_only_remembered_on_user_prompt", null) == null ? var.device_configuration_device_only_remembered_on_user_prompt : lookup(var.device_configuration, "device_only_remembered_on_user_prompt")
   }]

--- a/variables.tf
+++ b/variables.tf
@@ -638,3 +638,9 @@ variable "identity_providers" {
   default     = []
   sensitive   = true
 }
+
+variable "enable_propagate_additional_user_context_data" {
+  description = "Enables the propagation of additional user context data"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
This pull request includes enhancements and fixes related to the propagation of additional user context data and improvements to documentation and configuration handling.

### Enhancements:
* Added `enable_propagate_additional_user_context_data` option to propagate additional user context data (`client.tf`, `variables.tf`, `README.md`). [[1]](diffhunk://#diff-51c2ff1ec3a3d0fb9411df4fab0c3b59acf28379d1b93723fdd9163bd94ce2f7R18) [[2]](diffhunk://#diff-51c2ff1ec3a3d0fb9411df4fab0c3b59acf28379d1b93723fdd9163bd94ce2f7R58) [[3]](diffhunk://#diff-51c2ff1ec3a3d0fb9411df4fab0c3b59acf28379d1b93723fdd9163bd94ce2f7R82) [[4]](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR641-R646) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R213) (thanks @AzgadGZ-CH)

### Fixes:
* Fixed perpetual in-place replacement issue for `device_configuration` and added comments to the complete example regarding sensitive data handling (`main.tf`, `examples/complete/main.tf`). [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL263-R264) [[2]](diffhunk://#diff-07f337e38ed1996f30ee4f04357ab23318c254cb606aaf4745d564cbd546722dL257-R258) (thanks @joelgaria)

### Documentation:
* Updated `CHANGELOG.md` to reflect the new enhancements and fixes in version 0.32.0. (thanks @lgallard)