### PR TITLE
refactor(cognito): switch user groups from count to for_each

### DIFF
--- a/user-group.tf
+++ b/user-group.tf
@@ -1,9 +1,9 @@
 resource "aws_cognito_user_group" "main" {
-  count        = var.enabled ? length(local.groups) : 0
-  name         = lookup(element(local.groups, count.index), "name")
-  description  = lookup(element(local.groups, count.index), "description")
-  precedence   = lookup(element(local.groups, count.index), "precedence")
-  role_arn     = lookup(element(local.groups, count.index), "role_arn")
+  for_each     = var.enabled ? { for group in local.groups : group.name => group } : {}
+  name         = each.key
+  description  = lookup(each.value, "description", null)
+  precedence   = lookup(each.value, "precedence", null)
+  role_arn     = lookup(each.value, "role_arn", null)
   user_pool_id = aws_cognito_user_pool.pool[0].id
 }
 


### PR DESCRIPTION
# Switch Cognito User Groups from count to for_each

## Changes
- Replaces `count`-based iteration with `for_each` in Cognito user group resources
- Uses group name as the resource identifier instead of list index
- Maintains existing lookup functionality for optional attributes

## Motivation
The previous implementation used `count` with a list of groups, which made the resources sensitive to list order changes. Any reordering of the groups would cause Terraform to destroy and recreate the groups, even when only the order changed. By switching to `for_each` with the group name as the key, we ensure stable resource identifiers that are independent of list order.

## ⚠️ Breaking Change
This change modifies how Terraform identifies user groups, which will trigger recreation of existing groups. This requires careful handling during deployment.

### Migration Steps
1. Before applying:
   - Export existing user group memberships to a backup location
   - You can use AWS CLI or SDK:
     ```bash
     aws cognito-idp list-users-in-group --user-pool-id <pool_id> --group-name <group_name>
     ```
2. Apply the changes
3. After applying:
   - Restore user group memberships from backup
   - You can use AWS CLI or SDK:
     ```bash
     aws cognito-idp admin-add-user-to-group --user-pool-id <pool_id> --group-name <group_name> --username <username>
     ```

