### PR TITLE
feat: support user pool tier option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module "aws_cognito_user_pool_complete" {
   user_pool_name           = "mypool"
   alias_attributes         = ["email", "phone_number"]
   auto_verified_attributes = ["email"]
+  user_pool_tier           = "ESSENTIALS" # Valid values: LITE, ESSENTIALS, PLUS. Default is ESSENTIALS
 
   deletion_protection = "ACTIVE"
 

--- a/main.tf
+++ b/main.tf
@@ -11,6 +11,7 @@ resource "aws_cognito_user_pool" "pool" {
   sms_verification_message   = var.sms_verification_message
   username_attributes        = var.username_attributes
   deletion_protection        = var.deletion_protection
+  user_pool_tier             = var.user_pool_tier
 
   # username_configuration
   dynamic "username_configuration" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,16 @@ variable "user_pool_name" {
   type        = string
 }
 
+variable "user_pool_tier" {
+  type        = string
+  description = "Cognito User Pool tier. Valid values: LITE, ESSENTIALS, PLUS."
+  default     = "ESSENTIALS"
+  validation {
+    condition     = contains(["LITE", "ESSENTIALS", "PLUS"], var.user_pool_tier)
+    error_message = "user_pool_tier must be one of: LITE, ESSENTIALS, PLUS"
+  }
+}
+
 variable "email_verification_message" {
   description = "A string representing the email verification message"
   type        = string


### PR DESCRIPTION
support setting user pool tier.

Requested feature at https://github.com/lgallard/terraform-aws-cognito-user-pool/issues/167

Default value gets set to Essentials because as per AWS documentation https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-sign-in-feature-plans.html "The default plan selection for new user pools is Essentials."

user_pool_tier option was introduced to aws provider at version 5.83 https://github.com/hashicorp/terraform-provider-aws/blob/v5.83.0/CHANGELOG.md so the existing min 5.95 version constraint at https://github.com/lgallard/terraform-aws-cognito-user-pool/blob/master/versions.tf#L6 satisfies the introduced attribute