### PR TITLE
fix: resolve unsupported attribute error for user_groups_map ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ If you need to add new schema attributes after enabling `ignore_schema_changes =
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.95 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.2.0 |
 
 ## Modules
 
@@ -461,7 +461,7 @@ This is needed because all parameters for the `lambda_config` block are optional
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.0.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.2.0 |
 
 ## Modules
 
@@ -585,6 +585,7 @@ No modules.
 | <a name="input_user_pool_add_ons"></a> [user\_pool\_add\_ons](#input\_user\_pool\_add\_ons) | Configuration block for user pool add-ons to enable user pool advanced security mode features | `map(any)` | `{}` | no |
 | <a name="input_user_pool_add_ons_advanced_security_mode"></a> [user\_pool\_add\_ons\_advanced\_security\_mode](#input\_user\_pool\_add\_ons\_advanced\_security\_mode) | The mode for advanced security, must be one of `OFF`, `AUDIT` or `ENFORCED` | `string` | `null` | no |
 | <a name="input_user_pool_name"></a> [user\_pool\_name](#input\_user\_pool\_name) | The name of the user pool | `string` | n/a | yes |
+| <a name="input_user_pool_tier"></a> [user\_pool\_tier](#input\_user\_pool\_tier) | Cognito User Pool tier. Valid values: LITE, ESSENTIALS, PLUS. | `string` | `"ESSENTIALS"` | no |
 | <a name="input_username_attributes"></a> [username\_attributes](#input\_username\_attributes) | Specifies whether email addresses or phone numbers can be specified as usernames when a user signs up. Conflicts with `alias_attributes` | `list(string)` | `null` | no |
 | <a name="input_username_configuration"></a> [username\_configuration](#input\_username\_configuration) | The Username Configuration. Setting `case_sensitive` specifies whether username case sensitivity will be applied for all users in the user pool through Cognito APIs | `map(any)` | `{}` | no |
 | <a name="input_verification_message_template"></a> [verification\_message\_template](#input\_verification\_message\_template) | The verification message templates configuration | `map(any)` | `{}` | no |
@@ -615,4 +616,8 @@ No modules.
 | <a name="output_last_modified_date"></a> [last\_modified\_date](#output\_last\_modified\_date) | The date the user pool was last modified |
 | <a name="output_name"></a> [name](#output\_name) | The name of the user pool |
 | <a name="output_resource_servers_scope_identifiers"></a> [resource\_servers\_scope\_identifiers](#output\_resource\_servers\_scope\_identifiers) | A list of all scopes configured in the format identifier/scope\_name |
+| <a name="output_user_group_arns"></a> [user\_group\_arns](#output\_user\_group\_arns) | The ARNs of the user groups |
+| <a name="output_user_group_ids"></a> [user\_group\_ids](#output\_user\_group\_ids) | The ids of the user groups |
+| <a name="output_user_group_names"></a> [user\_group\_names](#output\_user\_group\_names) | The names of the user groups |
+| <a name="output_user_groups_map"></a> [user\_groups\_map](#output\_user\_groups\_map) | A map of user group names to their properties |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -101,7 +101,9 @@ output "user_group_names" {
 
 output "user_group_arns" {
   description = "The ARNs of the user groups"
-  value       = var.enabled ? values(aws_cognito_user_group.main)[*].arn : null
+  value = var.enabled ? [
+    for group in values(aws_cognito_user_group.main) : "${local.user_pool.arn}/group/${group.name}"
+  ] : null
 }
 
 output "user_groups_map" {
@@ -113,7 +115,7 @@ output "user_groups_map" {
       description = v.description
       precedence  = v.precedence
       role_arn    = v.role_arn
-      arn         = v.arn
+      arn         = "${local.user_pool.arn}/group/${v.name}"
     }
   } : null
 }


### PR DESCRIPTION
## Summary
- Fixes unsupported attribute error when accessing `.arn` on `aws_cognito_user_group` resource
- The `aws_cognito_user_group` resource does not expose an `arn` attribute in the Terraform AWS provider
- Constructs user group ARNs manually using the user pool ARN and group name

## Changes
- Updated `user_group_arns` output to construct ARNs using `"${local.user_pool.arn}/group/${group.name}"`
- Updated `user_groups_map` output to use the same constructed ARN pattern
- ARN format follows AWS standard: `arn:aws:cognito-idp:region:account-id:userpool/user-pool-id/group/group-name`

## Test plan
- [x] Terraform validation passes
- [x] Configuration syntax is correct
- [x] Maintains backward compatibility
- [x] README.md updated with terraform-docs

Fixes #205