### PR TITLE
Fix color_mode validation errors in with_branding example

### DIFF
--- a/examples/with_branding/README.md
+++ b/examples/with_branding/README.md
@@ -79,11 +79,11 @@ Cognito supports various asset categories:
 
 | Category | Description | Color Modes |
 |----------|-------------|-------------|
-| `FORM_LOGO` | Logo on login form | LIGHT, DARK, BROWSER_ADAPTIVE |
-| `PAGE_BACKGROUND` | Page background | LIGHT, DARK, BROWSER_ADAPTIVE |
-| `FAVICON_ICO` | Browser favicon | BROWSER_ADAPTIVE |
-| `PAGE_HEADER_LOGO` | Header logo | LIGHT, DARK, BROWSER_ADAPTIVE |
-| `PAGE_FOOTER_LOGO` | Footer logo | LIGHT, DARK, BROWSER_ADAPTIVE |
+| `FORM_LOGO` | Logo on login form | LIGHT, DARK, DYNAMIC |
+| `PAGE_BACKGROUND` | Page background | LIGHT, DARK, DYNAMIC |
+| `FAVICON_ICO` | Browser favicon | DYNAMIC |
+| `PAGE_HEADER_LOGO` | Header logo | LIGHT, DARK, DYNAMIC |
+| `PAGE_FOOTER_LOGO` | Footer logo | LIGHT, DARK, DYNAMIC |
 
 ## Outputs
 

--- a/examples/with_branding/assets/README.md
+++ b/examples/with_branding/assets/README.md
@@ -28,7 +28,7 @@ This directory should contain the branding assets referenced in the example:
 ### Color Modes
 - `LIGHT` - Assets for light theme
 - `DARK` - Assets for dark theme  
-- `BROWSER_ADAPTIVE` - Assets that adapt to browser preference
+- `DYNAMIC` - Assets that adapt to browser preference
 
 ## Quick Start - Generate Sample Assets
 

--- a/examples/with_branding/main.tf
+++ b/examples/with_branding/main.tf
@@ -57,13 +57,13 @@ module "aws_cognito_user_pool" {
         {
           bytes      = filebase64("${path.module}/assets/background.svg")
           category   = "PAGE_BACKGROUND"
-          color_mode = "BROWSER_ADAPTIVE"
+          color_mode = "DYNAMIC"
           extension  = "SVG"
         },
         {
           bytes      = filebase64("${path.module}/assets/favicon.svg")
           category   = "FAVICON_ICO"
-          color_mode = "BROWSER_ADAPTIVE"
+          color_mode = "DYNAMIC"
           extension  = "SVG"
         }
       ]

--- a/variables.tf
+++ b/variables.tf
@@ -777,11 +777,11 @@ variable "managed_login_branding" {
     condition = alltrue([
       for config in values(var.managed_login_branding) : alltrue([
         for asset in lookup(config, "assets", []) : contains([
-          "LIGHT", "DARK", "BROWSER_ADAPTIVE"
+          "LIGHT", "DARK", "DYNAMIC"
         ], asset.color_mode)
       ])
     ])
-    error_message = "Invalid color_mode. Must be one of: LIGHT, DARK, BROWSER_ADAPTIVE"
+    error_message = "Invalid color_mode. Must be one of: LIGHT, DARK, DYNAMIC"
 
   }
 


### PR DESCRIPTION
## Summary

Fixes color_mode validation errors in the `examples/with_branding` example that occur when using the awscc provider.

## Problem

The with_branding example used `"BROWSER_ADAPTIVE"` as color_mode values for background and favicon assets, but the awscc provider only accepts `["LIGHT", "DARK", "DYNAMIC"]`. This caused terraform plan to fail with validation errors.

## Solution

- **Changed** `"BROWSER_ADAPTIVE"` to `"DYNAMIC"` in `examples/with_branding/main.tf` (lines 60, 66)
- **Updated** validation rule in `variables.tf` to accept `"DYNAMIC"` instead of `"BROWSER_ADAPTIVE"`

## Testing

✅ `terraform validate` passes  
✅ `terraform plan` executes without validation errors  
✅ awscc_cognito_managed_login_branding resource creates successfully  

## Files Changed

- `examples/with_branding/main.tf` - Updated asset color_mode values
- `variables.tf` - Updated validation rule for color_mode

## Impact

- ✅ **Fixes** validation errors for users of the with_branding example
- ✅ **Maintains** same functionality with correct awscc provider values
- ✅ **No breaking changes** - DYNAMIC provides equivalent adaptive behavior

Related to issue #214 - discovered during testing of the assets block fix.