### PR TITLE
Fix: document color_mode validation requirements for awscc provider

### DIFF
--- a/managed-login-branding.tf
+++ b/managed-login-branding.tf
@@ -1,5 +1,6 @@
 # AWS Cloud Control API provider is required for managed login branding
 # Ensure awscc provider is configured in your root module when enabling this feature
+# Note: color_mode values must be one of: LIGHT, DARK, DYNAMIC (for awscc provider compatibility)
 resource "awscc_cognito_managed_login_branding" "branding" {
   for_each = var.enabled && var.managed_login_branding_enabled ? var.managed_login_branding : {}
 


### PR DESCRIPTION
Follow-up to PR #235 with proper conventional commit to trigger release-please version bump. Adds inline documentation about color_mode values (LIGHT, DARK, DYNAMIC) for awscc provider compatibility.