### PR TITLE
fix(examples): improve with_branding example configuration and assets

### DIFF
--- a/examples/with_branding/assets/favicon.svg
+++ b/examples/with_branding/assets/favicon.svg
@@ -1,4 +1,4 @@
 <svg width="32" height="32" xmlns="http://www.w3.org/2000/svg">
   <rect width="32" height="32" fill="#007bff"/>
-  <text x="16" y="20" font-family="Arial, sans-serif" font-size="14" fill="white" text-anchor="middle" dominant-baseline="middle">A</text>
+  <text x="16" y="22" font-family="Arial, sans-serif" font-size="14" fill="white" text-anchor="middle">A</text>
 </svg>

--- a/examples/with_branding/assets/logo-dark.svg
+++ b/examples/with_branding/assets/logo-dark.svg
@@ -1,4 +1,4 @@
-<svg width="200" height="60" xmlns="http://www.w3.org/2000/svg">
-  <rect width="200" height="60" fill="#ffffff"/>
-  <text x="100" y="35" font-family="Arial, sans-serif" font-size="16" fill="#212529" text-anchor="middle" dominant-baseline="middle">My App</text>
+<svg width="300" height="80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="80" rx="8" fill="#ffffff" stroke="#e0e0e0" stroke-width="1"/>
+  <text x="150" y="50" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="#212529" text-anchor="middle">My App</text>
 </svg>

--- a/examples/with_branding/assets/logo-light.svg
+++ b/examples/with_branding/assets/logo-light.svg
@@ -1,4 +1,4 @@
-<svg width="200" height="60" xmlns="http://www.w3.org/2000/svg">
-  <rect width="200" height="60" fill="#007bff"/>
-  <text x="100" y="35" font-family="Arial, sans-serif" font-size="16" fill="white" text-anchor="middle" dominant-baseline="middle">My App</text>
+<svg width="300" height="80" xmlns="http://www.w3.org/2000/svg">
+  <rect width="300" height="80" rx="8" fill="#007bff"/>
+  <text x="150" y="50" font-family="Arial, sans-serif" font-size="24" font-weight="bold" fill="white" text-anchor="middle">My App</text>
 </svg>

--- a/examples/with_branding/main.tf
+++ b/examples/with_branding/main.tf
@@ -44,6 +44,18 @@ module "aws_cognito_user_pool" {
       assets = [
         {
           bytes      = filebase64("${path.module}/assets/logo-light.svg")
+          category   = "PAGE_HEADER_LOGO"
+          color_mode = "LIGHT"
+          extension  = "SVG"
+        },
+        {
+          bytes      = filebase64("${path.module}/assets/logo-dark.svg")
+          category   = "PAGE_HEADER_LOGO"
+          color_mode = "DARK"
+          extension  = "SVG"
+        },
+        {
+          bytes      = filebase64("${path.module}/assets/logo-light.svg")
           category   = "FORM_LOGO"
           color_mode = "LIGHT"
           extension  = "SVG"
@@ -60,35 +72,9 @@ module "aws_cognito_user_pool" {
           color_mode = "DYNAMIC"
           extension  = "SVG"
         },
-        {
-          bytes      = filebase64("${path.module}/assets/favicon.svg")
-          category   = "FAVICON_ICO"
-          color_mode = "DYNAMIC"
-          extension  = "SVG"
-        }
       ]
-      settings = jsonencode({
-        "colorScheme" = {
-          "light" = {
-            "primary"    = "#007bff"
-            "secondary"  = "#6c757d"
-            "background" = "#ffffff"
-          }
-          "dark" = {
-            "primary"    = "#0d6efd"
-            "secondary"  = "#adb5bd"
-            "background" = "#212529"
-          }
-        }
-        "typography" = {
-          "fontFamily" = "Arial, sans-serif"
-          "fontSize"   = "16px"
-        }
-        "layout" = {
-          "borderRadius" = "8px"
-          "spacing"      = "16px"
-        }
-      })
+# Use AWS default values for styling, just custom assets
+      use_cognito_provided_values = true
       return_merged_resources = true
     }
   } : {}

--- a/examples/with_branding/main.tf
+++ b/examples/with_branding/main.tf
@@ -73,9 +73,9 @@ module "aws_cognito_user_pool" {
           extension  = "SVG"
         },
       ]
-# Use AWS default values for styling, just custom assets
+      # Use AWS default values for styling, just custom assets
       use_cognito_provided_values = true
-      return_merged_resources = true
+      return_merged_resources     = true
     }
   } : {}
 

--- a/examples/with_branding/terraform.tfvars
+++ b/examples/with_branding/terraform.tfvars
@@ -3,8 +3,11 @@
 user_pool_name = "my-app-user-pool-with-branding"
 user_pool_tier = "ESSENTIALS"
 
+# Enable managed login branding
+enable_branding = true
+
 # Optional: Set a custom domain for hosted UI
-# domain_name = "my-app-auth"
+domain_name = "my-app-auth-branding-test-20250720"
 
 aws_region = "us-east-1"
 


### PR DESCRIPTION
## Summary

This PR fixes several critical issues with the `examples/with_branding` example to ensure AWS Cognito managed login branding works correctly out-of-the-box.

## Issues Fixed

### 🚫 **Configuration Problems**
- Missing `enable_branding = true` variable causing conditional logic to fail
- Incompatible settings JSON structure rejected by AWS API
- Generic domain name causing conflicts during testing

### 🎨 **Asset Issues** 
- SVG `dominant-baseline` attribute not allowed by AWS validation
- Logo size too small (200x60px) for good visibility
- FAVICON_ICO using SVG format instead of required ICO format
- Missing light/dark variants for different logo categories

## Changes Made

### ✅ **Configuration Fixes**
- ✅ Add `enable_branding = true` to `terraform.tfvars`
- ✅ Use `use_cognito_provided_values = true` for AWS-compatible settings
- ✅ Configure multiple asset categories: `PAGE_HEADER_LOGO`, `FORM_LOGO`, `PAGE_BACKGROUND`
- ✅ Add unique domain name with timestamp suffix

### 🎨 **Asset Improvements**
- ✅ Increase logo dimensions to 300x80px for better visibility
- ✅ Remove `dominant-baseline` SVG attribute (AWS requirement)
- ✅ Add rounded corners (8px) and bold typography
- ✅ Remove FAVICON_ICO asset (AWS requires ICO format)
- ✅ Provide both light and dark logo variants

## Test Results

- ✅ `terraform plan` and `terraform apply` succeed without errors
- ✅ Background gradient displays correctly on login page
- ✅ AWS Console shows managed login branding as "Available"
- ✅ All assets pass AWS API validation
- ✅ No SVG validation errors

## Before vs After

**Before:** 
- ❌ Terraform apply failed with "Unexpected Character" errors
- ❌ Asset validation errors for SVG attributes
- ❌ Domain conflicts during testing

**After:**
- ✅ Clean terraform apply with working branding
- ✅ AWS-compliant SVG assets
- ✅ Visible background customization
- ✅ Successful example deployment

## Verification

To test this fix:

1. Navigate to `examples/with_branding/`
2. Run `terraform init && terraform plan && terraform apply`
3. Visit the generated hosted UI URL
4. Verify background gradient and managed login branding status

This ensures the example works reliably for users implementing AWS Cognito managed login branding.