### PR TITLE
feat: complete verification message template support for SMS and email conflict resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ No modules.
 | <a name="input_verification_message_template_email_message_by_link"></a> [verification\_message\_template\_email\_message\_by\_link](#input\_verification\_message\_template\_email\_message\_by\_link) | The email message template for sending a confirmation link to the user, it must contain the `{##Click Here##}` placeholder | `string` | `null` | no |
 | <a name="input_verification_message_template_email_subject"></a> [verification\_message\_template\_email\_subject](#input\_verification\_message\_template\_email\_subject) | The subject line for the email message template for sending a confirmation code to the user | `string` | `null` | no |
 | <a name="input_verification_message_template_email_subject_by_link"></a> [verification\_message\_template\_email\_subject\_by\_link](#input\_verification\_message\_template\_email\_subject\_by\_link) | The subject line for the email message template for sending a confirmation link to the user | `string` | `null` | no |
+| <a name="input_verification_message_template_sms_message"></a> [verification\_message\_template\_sms\_message](#input\_verification\_message\_template\_sms\_message) | SMS message template. Must contain the {####} placeholder. Conflicts with sms\_verification\_message argument. | `string` | `null` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -4,8 +4,8 @@ resource "aws_cognito_user_pool" "pool" {
   alias_attributes           = var.alias_attributes
   auto_verified_attributes   = var.auto_verified_attributes
   name                       = var.user_pool_name
-  email_verification_subject = var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject
-  email_verification_message = var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message
+  email_verification_subject = local.verification_email_subject
+  email_verification_message = local.verification_email_message
   mfa_configuration          = var.mfa_configuration
   sms_authentication_message = var.sms_authentication_message
   sms_verification_message   = var.sms_verification_message
@@ -255,8 +255,8 @@ resource "aws_cognito_user_pool" "pool_with_schema_ignore" {
   alias_attributes           = var.alias_attributes
   auto_verified_attributes   = var.auto_verified_attributes
   name                       = var.user_pool_name
-  email_verification_subject = var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject
-  email_verification_message = var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message
+  email_verification_subject = local.verification_email_subject
+  email_verification_message = local.verification_email_message
   mfa_configuration          = var.mfa_configuration
   sms_authentication_message = var.sms_authentication_message
   sms_verification_message   = var.sms_verification_message
@@ -627,13 +627,21 @@ locals {
   # If no verification_message_template is provided, build a verification_message_template using the default values
   verification_message_template_default = {
     default_email_option  = lookup(var.verification_message_template, "default_email_option", null) == null ? var.verification_message_template_default_email_option : lookup(var.verification_message_template, "default_email_option")
-    email_message_by_link = lookup(var.verification_message_template, "email_message_by_link", null) == null ? var.verification_message_template_email_message_by_link : lookup(var.verification_message_template, "email_message_by_link")
-    email_subject_by_link = lookup(var.verification_message_template, "email_subject_by_link", null) == null ? var.verification_message_template_email_subject_by_link : lookup(var.verification_message_template, "email_subject_by_link")
     email_message         = lookup(var.verification_message_template, "email_message", null) == null ? var.verification_message_template_email_message : lookup(var.verification_message_template, "email_message")
+    email_message_by_link = lookup(var.verification_message_template, "email_message_by_link", null) == null ? var.verification_message_template_email_message_by_link : lookup(var.verification_message_template, "email_message_by_link")
     email_subject         = lookup(var.verification_message_template, "email_subject", null) == null ? var.verification_message_template_email_subject : lookup(var.verification_message_template, "email_subject")
+    email_subject_by_link = lookup(var.verification_message_template, "email_subject_by_link", null) == null ? var.verification_message_template_email_subject_by_link : lookup(var.verification_message_template, "email_subject_by_link")
+    sms_message           = lookup(var.verification_message_template, "sms_message", null) == null ? var.verification_message_template_sms_message : lookup(var.verification_message_template, "sms_message")
   }
 
   verification_message_template = [local.verification_message_template_default]
+
+  verification_email_subject = local.verification_message_template_default.email_subject == "" || local.verification_message_template_default.email_subject == null ? (
+    var.email_verification_subject == "" || var.email_verification_subject == null ? var.admin_create_user_config_email_subject : var.email_verification_subject
+  ) : null
+  verification_email_message = local.verification_message_template_default.email_message == "" || local.verification_message_template_default.email_message == null ? (
+    var.email_verification_message == "" || var.email_verification_message == null ? var.admin_create_user_config_email_message : var.email_verification_message
+  ) : null
 
   # software_token_mfa_configuration
   # If no software_token_mfa_configuration is provided, build a software_token_mfa_configuration using the default values

--- a/variables.tf
+++ b/variables.tf
@@ -444,6 +444,12 @@ variable "verification_message_template_email_subject_by_link" {
   default     = null
 }
 
+variable "verification_message_template_sms_message" {
+  description = "SMS message template. Must contain the {####} placeholder. Conflicts with sms_verification_message argument."
+  type        = string
+  default     = null
+}
+
 variable "verification_message_template_email_message" {
   description = "The email message template for sending a confirmation code to the user, it must contain the `{####}` placeholder"
   type        = string


### PR DESCRIPTION
## Summary

This PR completes the implementation proposed in PR #159 by adding support for SMS message template configuration and improving email verification message conflict resolution.

### Changes Made

- ✅ **Added `verification_message_template_sms_message` variable** for SMS template configuration
- ✅ **Added SMS message processing** to `verification_message_template_default` locals  
- ✅ **Implemented email conflict resolution logic** using `verification_email_subject` and `verification_email_message` locals
- ✅ **Updated both user pool resources** to use new email conflict resolution locals
- ✅ **Auto-updated documentation** via terraform-docs

### Background

PR #159 by @riccardolocci proposed adding support for `email_subject`, `email_message` and `sms_message` fields in `verification_message_template`. Upon analysis, ~70% of this functionality was already implemented in master, but the SMS message template support and email conflict resolution logic were missing.

### Functionality

This completes the verification message template functionality, enabling users to configure:

```hcl
verification_message_template = {
  email_message = "Your password reset code is {####}"
  email_subject = "Change password - Your verification code"  
  sms_message   = "Your verification code is {####}"
}
```

### Email Conflict Resolution

The implementation properly handles conflicts between template variables and direct message variables:
- When `verification_message_template.email_subject` is set → uses template value
- When `verification_message_template.email_subject` is null/empty → falls back to `email_verification_subject` or `admin_create_user_config_email_subject`
- Same logic applies to email messages

### Testing

- ✅ `terraform fmt` - formatting passed
- ✅ `terraform validate` - configuration is valid  
- ✅ `terraform-docs` - documentation auto-updated
- ✅ `terraform-tfsec` - security scanning passed
- ⚠️ `terraform-tflint` - existing deprecated syntax warnings (not related to this PR)

### Resolves

- Closes #48 (verification message template configuration)
- Completes implementation from PR #159

### Co-authored

This work builds upon the original proposal by @riccardolocci in PR #159.

Co-authored-by: riccardolocci <36544873+riccardolocci@users.noreply.github.com>