### PR TITLE
fix: correct advanced_security_additional_flows structure to use proper AWS provider block syntax

### DIFF
--- a/test/unit/variable_validation_test.go
+++ b/test/unit/variable_validation_test.go
@@ -214,6 +214,11 @@ func TestAdvancedSecurityAdditionalFlowsValidation(t *testing.T) {
 			shouldFail:                      false,
 		},
 		{
+			name:                            "InvalidEmptyString",
+			advancedSecurityAdditionalFlows: "",
+			shouldFail:                      true,
+		},
+		{
 			name:                            "InvalidLowercaseAudit",
 			advancedSecurityAdditionalFlows: "audit",
 			shouldFail:                      true,


### PR DESCRIPTION
## Summary
Fixes the `advanced_security_additional_flows` implementation to use the correct AWS provider block syntax instead of a simple argument.

## Problem
The feature was incorrectly implemented as a simple argument accepting an array of auth flows:
```hcl
advanced_security_additional_flows = ["ADMIN_NO_SRP_AUTH", "CUSTOM_AUTH_FLOW_ONLY"]
```

But AWS provider requires it as a **block** containing a `custom_auth_mode` attribute:
```hcl
advanced_security_additional_flows {
  custom_auth_mode = "AUDIT"  # or "ENFORCED"
}
```

This caused terraform plan to fail with:
> An argument named "advanced_security_additional_flows" is not expected here. Did you mean to define a block of type "advanced_security_additional_flows"?

## Solution
- **Variable Interface**: Changed from `set(string)` to `string` accepting `AUDIT` or `ENFORCED` values
- **Terraform Structure**: Replaced simple argument with proper dynamic block structure  
- **Examples & Docs**: Updated all usage examples and documentation
- **Tests**: Added comprehensive validation tests

## Usage
```hcl
module "cognito_user_pool" {
  source  = "lgallard/cognito-user-pool/aws"
  
  user_pool_add_ons_advanced_security_mode             = "AUDIT"
  user_pool_add_ons_advanced_security_additional_flows = "AUDIT"  # or "ENFORCED"
}
```

## Testing
- ✅ Added validation tests for new variable structure
- ✅ Confirmed existing tests still pass
- ✅ Verified terraform validate passes

## Type of Change
**Bug fix** - The previous implementation never worked, so this fixes broken functionality rather than introducing breaking changes.

Closes #262