### PR TITLE
feat: add MCP server support for enhanced documentation access

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,6 +40,30 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # MCP Configuration for Terraform and Context7 documentation access
+          mcp_config: |
+            {
+              "mcpServers": {
+                "terraform": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-terraform@latest"
+                  ]
+                },
+                "context7": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@upstash/context7-mcp@latest"
+                  ]
+                }
+              }
+            }
+
+          # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
 
@@ -48,9 +72,6 @@ jobs:
 
           # Optional: Trigger when specific user is assigned to an issue
           # assignee_trigger: "claude-bot"
-
-          # Optional: Allow Claude to run specific commands
-          # allowed_tools: "Bash(npm install),Bash(npm run build),Bash(npm run test:*),Bash(npm run lint:*)"
 
           # Optional: Add custom instructions for Claude to customize its behavior for your project
           # custom_instructions: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,3 +233,78 @@ terraform {
 ```
 
 *Note: Version constraints should be chosen based on actual requirements and compatibility needs.*
+
+## MCP Server Configuration
+
+### Available MCP Servers
+This project is configured to use the following Model Context Protocol (MCP) servers for enhanced documentation access:
+
+#### Terraform MCP Server
+**Purpose**: Access up-to-date Terraform and AWS provider documentation
+**Package**: `@modelcontextprotocol/server-terraform`
+
+**Local Configuration** (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "terraform": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-terraform@latest"]
+    }
+  }
+}
+```
+
+**Usage Examples**:
+- `Look up aws_cognito_user_pool resource documentation`
+- `Find the latest Cognito User Pool client configuration examples`  
+- `Search for AWS Cognito Terraform modules`
+- `Get documentation for aws_cognito_identity_provider resource`
+
+#### Context7 MCP Server  
+**Purpose**: Access general library and framework documentation
+**Package**: `@upstash/context7-mcp`
+
+**Local Configuration** (`.mcp.json`):
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx", 
+      "args": ["-y", "@upstash/context7-mcp@latest"]
+    }
+  }
+}
+```
+
+**Usage Examples**:
+- `Look up Go testing patterns for Terratest`
+- `Find AWS CLI cognito commands documentation`
+- `Get current Terraform best practices`
+- `Search for GitHub Actions workflow patterns`
+
+### GitHub Actions Integration
+The MCP servers are automatically available in GitHub Actions through the claude.yml workflow configuration. Claude can access the same documentation in PRs and issues as available locally.
+
+### Usage Tips
+1. **Be Specific**: When requesting documentation, specify the exact resource or concept
+2. **Version Awareness**: Both servers provide current, version-specific documentation  
+3. **Combine Sources**: Use Terraform MCP for Cognito-specific docs, Context7 for general development patterns
+4. **Local vs CI**: Same MCP servers work in both local development and GitHub Actions
+
+### Example Workflows
+
+**Cognito Resource Development**:
+```
+@claude I need to add support for Cognito advanced security features. Can you look up the latest aws_cognito_user_pool advanced_security_mode documentation and show me how to implement this feature?
+```
+
+**Testing Pattern Research**:
+```  
+@claude Look up current Terratest patterns for testing Cognito User Pools and help me add comprehensive tests for user pool clients and identity providers.
+```
+
+**Security Enhancement**:
+```
+@claude Research the latest AWS Cognito security best practices and help me implement enhanced MFA configurations in this module.
+```


### PR DESCRIPTION
## Summary
- Add Terraform MCP server for AWS Cognito provider and module documentation access
- Add Context7 MCP server for general library documentation access  
- Update GitHub Actions workflow to configure both MCP servers
- Document MCP server configuration and usage in CLAUDE.md with Cognito-specific examples

## Test plan
- [x] YAML syntax validation passed
- [x] MCP configuration JSON validation passed  
- [x] Documentation updated with AWS Cognito-specific usage examples

This enables Claude to access up-to-date AWS Cognito documentation from official sources both in local development and GitHub Actions, providing consistent and accurate code assistance for identity and access management infrastructure development.