### PR TITLE
feat: update AWS provider version constraints to >= 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95"
+      version = ">= 6.0"
     }
     awscc = {
       source  = "hashicorp/awscc"

--- a/examples/with_branding/README.md
+++ b/examples/with_branding/README.md
@@ -27,7 +27,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95"
+      version = ">= 6.0"
     }
     awscc = {
       source  = "hashicorp/awscc"
@@ -137,7 +137,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.95 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 1.0 |
 
 ## Providers

--- a/examples/with_branding/provider.tf
+++ b/examples/with_branding/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.95"
+      version = ">= 6.0"
     }
 
     # Required for managed login branding


### PR DESCRIPTION
Updates remaining AWS provider version constraints from >= 5.95 to >= 6.0 to ensure consistency across all examples and documentation.

## Changes
- Update examples/with_branding/provider.tf version constraint
- Update examples/with_branding/README.md requirements table
- Update main README.md branding example

Closes #280

Generated with [Claude Code](https://claude.ai/code)