### PR TITLE
fix: configure Renovate to prevent pre-release Go versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,19 @@
       "matchPackagePatterns": ["^hashicorp/terraform$"],
       "enabled": true,
       "automerge": false
+    },
+    {
+      "matchDatasources": ["golang-version"],
+      "ignoreUnstable": true,
+      "respectLatest": true,
+      "description": "Prevent pre-release Go versions in GitHub Actions workflows"
+    },
+    {
+      "managers": ["github-actions"],
+      "matchPackageNames": ["actions/setup-go"],
+      "ignoreUnstable": true,
+      "respectLatest": true,
+      "description": "Ensure setup-go action only uses stable Go versions"
     }
   ]
 }


### PR DESCRIPTION
Fixes #293

This PR addresses the failing tests by configuring Renovate to prevent future pre-release Go version suggestions.

## Changes

- Added golang-version datasource rule with ignoreUnstable: true
- Added GitHub Actions setup-go rule to prevent unstable versions
- Prevents future suggestions of Go release candidates (like 1.24rc1)

## Manual Action Required

To complete the fix, you need to manually update `.github/workflows/test.yml`:
- Change `go-version: '1.24'` to `go-version: '1.23'` on lines 25, 60, and 161

Generated with [Claude Code](https://claude.ai/code)