### PR TITLE
fix: correct pre-commit typo and validation errors

### DIFF
--- a/examples/simple_extended/README.md
+++ b/examples/simple_extended/README.md
@@ -68,7 +68,7 @@ module "aws_cognito_user_pool_simple_extended_example" {
   user_group_name        = "mygroup"
   user_group_description = "My group"
 
-  # ressource server
+  # resource server
   resource_server_identifier        = "https://mydomain.com"
   resource_server_name              = "mydomain"
   resource_server_scope_name        = "scope"

--- a/test/fixtures/complete-config/main.tf
+++ b/test/fixtures/complete-config/main.tf
@@ -26,7 +26,7 @@ module "cognito_user_pool_test" {
   user_groups = var.user_groups
 
   # Account recovery
-  account_recovery_setting = var.account_recovery_setting
+  recovery_mechanisms = var.recovery_mechanisms
 
   # Advanced security
   user_pool_add_ons = var.user_pool_add_ons

--- a/test/fixtures/complete-config/outputs.tf
+++ b/test/fixtures/complete-config/outputs.tf
@@ -28,19 +28,19 @@ output "endpoint" {
   value       = module.cognito_user_pool_test.endpoint
 }
 
-output "domain" {
-  description = "Holds the domain prefix if the user pool has a domain associated with it"
-  value       = module.cognito_user_pool_test.domain
+output "domain_aws_account_id" {
+  description = "Domain AWS account ID"
+  value       = module.cognito_user_pool_test.domain_aws_account_id
 }
 
-output "clients" {
-  description = "User pool clients"
-  value       = module.cognito_user_pool_test.clients
+output "client_ids" {
+  description = "User pool client IDs"
+  value       = module.cognito_user_pool_test.client_ids
 }
 
-output "user_groups" {
-  description = "User groups"
-  value       = module.cognito_user_pool_test.user_groups
+output "user_group_ids" {
+  description = "User group IDs"
+  value       = module.cognito_user_pool_test.user_group_ids
 }
 
 output "managed_login_branding" {
@@ -48,7 +48,7 @@ output "managed_login_branding" {
   value       = module.cognito_user_pool_test.managed_login_branding
 }
 
-output "ui_customization" {
-  description = "UI customization"
-  value       = module.cognito_user_pool_test.ui_customization
+output "managed_login_branding_details" {
+  description = "Managed login branding details"
+  value       = module.cognito_user_pool_test.managed_login_branding_details
 }

--- a/test/fixtures/complete-config/variables.tf
+++ b/test/fixtures/complete-config/variables.tf
@@ -63,10 +63,10 @@ variable "user_groups" {
   default     = []
 }
 
-variable "account_recovery_setting" {
-  description = "Account recovery settings"
-  type        = map(any)
-  default     = {}
+variable "recovery_mechanisms" {
+  description = "Recovery mechanisms for account recovery"
+  type        = list(any)
+  default     = []
 }
 
 variable "user_pool_add_ons" {


### PR DESCRIPTION
## Summary
- Fix typo: changed 'ressource' to 'resource' in simple_extended example
- Fixed test fixture validation errors by correcting variable names
- Updated test fixture outputs to match available module outputs  
- Resolves pre-commit hook failures for clean CI/CD pipeline

## Test plan
- [x] All pre-commit hooks pass
- [x] Terraform validate passes  
- [x] Typos check passes
- [x] Formatting checks pass

Fixes the typo identified by pre-commit and ensures all validation passes cleanly.