### PR TITLE
fix: Update Claude Code Action parameters to correct format

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -592,11 +592,8 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Allow Bash permissions for pre-commit hooks and documentation updates
-          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs)"
-
           # Dynamic prompt based on review mode
-          direct_prompt: |
+          prompt: |
             🔄 **COMMIT ANALYSIS CONTEXT**
             - **Commit SHA**: `${{ steps.verify-state.outputs.current_sha }}`
             - **Review ID**: `${{ steps.verify-state.outputs.review_id }}`
@@ -676,7 +673,6 @@ jobs:
 
           # Use sticky comments with commit-specific cache invalidation
           use_sticky_comment: true
-          # Note: The commit SHA and review ID in the prompt help ensure fresh analysis
 
       - name: Workflow Summary
         if: always()


### PR DESCRIPTION
## Problem
The Claude Code Review workflow was using deprecated parameter names:
- `allowed_tools` (deprecated)  
- `direct_prompt` (should be `prompt`)

This caused configuration warnings in workflow runs, though the bot was still functioning.

## Solution  
- Updated `direct_prompt` to `prompt` parameter
- Removed deprecated `allowed_tools` parameter
- Simplified configuration to use supported parameters

## Result
- Eliminates configuration warnings in workflow runs
- Maintains full functionality of the codebot
- Uses officially supported Claude Code Action parameters

Fixes workflow configuration warnings seen in recent runs.