### PR TITLE
fix: resolve Claude Code Action comment posting issues

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -142,6 +142,8 @@ jobs:
       pull-requests: write
       issues: write
       id-token: write
+      actions: read  # For Claude to read CI results
+      # Note: reactions permission is implicitly included in issues:write
 
     steps:
       - name: Get PR information for checkout
@@ -702,8 +704,8 @@ jobs:
             Use appropriate subagents: @terraform-cognito for Cognito configs, @terraform-security for security, @terraform-testing for tests
             ', steps.parse-command.outputs.focus, steps.parse-command.outputs.verbose) || '' }}
 
-          # Use sticky comments with commit-specific cache invalidation
-          use_sticky_comment: true
+          # Disable sticky comments to ensure analysis comments are visible
+          use_sticky_comment: false
 
       - name: Workflow Summary
         if: always()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -625,6 +625,9 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           trigger_phrase: "codebot"
 
+          # Allow Claude to post comments and use MCP tools
+          allowed_tools: "mcp__github_comment__update_claude_comment,mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+
           # Dynamic prompt based on review mode
           prompt: |
             🔄 **COMMIT ANALYSIS CONTEXT**

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -704,8 +704,9 @@ jobs:
             Use appropriate subagents: @terraform-cognito for Cognito configs, @terraform-security for security, @terraform-testing for tests
             ', steps.parse-command.outputs.focus, steps.parse-command.outputs.verbose) || '' }}
 
-          # Disable sticky comments to ensure analysis comments are visible
-          use_sticky_comment: false
+          # Enable sticky comments and progress tracking for visible analysis
+          use_sticky_comment: true
+          track_progress: true
 
       - name: Workflow Summary
         if: always()

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -126,7 +126,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   claude:
-    # Only run on comment triggers or specific PR conditions
+    # Run on codebot comment triggers or specific PR conditions
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, 'codebot')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, 'codebot')) ||
@@ -139,8 +139,8 @@ jobs:
     timeout-minutes: 15  # Prevent runaway executions
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
@@ -198,6 +198,36 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # For issue_comment events, checkout the PR branch
           ref: ${{ github.event_name == 'issue_comment' && steps.pr-checkout-info.outputs.pr_head_ref || github.ref }}
+
+      - name: Add eyes reaction to show codebot is working
+        if: |
+          (github.event_name == 'issue_comment' && contains(github.event.comment.body, 'codebot')) ||
+          (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, 'codebot'))
+        timeout-minutes: 1
+        run: |
+          set -euo pipefail
+
+          # Add eyes emoji reaction to indicate codebot is processing
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            COMMENT_ID="${{ github.event.comment.id }}"
+          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
+            COMMENT_ID="${{ github.event.comment.id }}"
+          else
+            echo "No comment to react to for event type: ${{ github.event_name }}"
+            exit 0
+          fi
+
+          echo "Adding 👀 reaction to comment ID: $COMMENT_ID"
+          gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
+            --method POST \
+            --field content='eyes' || {
+            echo "Failed to add reaction - this might be expected for some comment types"
+            exit 0
+          }
+
+          echo "✅ Eyes reaction added successfully"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Refresh git state
         id: git-refresh
@@ -591,6 +621,7 @@ jobs:
         uses: anthropics/claude-code-action@v1.0.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          trigger_phrase: "codebot"
 
           # Dynamic prompt based on review mode
           prompt: |

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 Terraform module to create [Amazon Cognito User Pools](https://aws.amazon.com/cognito/), configure its attributes and resources such as  **app clients**, **domain**, **resource servers**. Amazon Cognito User Pools provide a secure user directory that scales to hundreds of millions of users. As a fully managed service, User Pools are easy to set up without any worries about standing up server infrastructure.
 
+<!-- Test comment for codebot workflow verification -->
+
 ## Usage
 
 You can use this module to create a Cognito User Pool using the default values or use the detailed definition to set every aspect of the Cognito User Pool


### PR DESCRIPTION
## 🔧 Fixes for Claude Code Action Comment Posting

This PR resolves the issue where Claude Code Action runs successfully but analysis comments don't appear on PRs.

### Key Fixes:

1. **Added  permissions** - Claude Code Action needs explicit permission to use 
2. **Enabled ** - Required in v1.0 for visible progress and analysis comments  
3. **Restored ** - Works properly with claude_code_oauth_token authentication

### Root Cause:
Claude Code Action was blocked from posting comments due to missing tool permissions. Analysis was successful but comments couldn't be posted.

### Testing:
- ✅ Eyes emoji reactions work
- ✅ Workflows no longer skip
- ✅ Analysis generates successfully  
- 🔄 Analysis comments should now appear

Related to codebot workflow debugging.