### PR TITLE
fix: separate token usage for PR info and repository dispatch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,8 +78,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get PR information and trigger dispatch
-        timeout-minutes: 3
+      - name: Get PR information
+        id: pr-info
+        timeout-minutes: 2
         run: |
           set -euo pipefail
 
@@ -118,6 +119,19 @@ jobs:
           echo "PR Head: $HEAD_REF ($HEAD_SHA)"
           echo "PR Base: $BASE_REF"
 
+          # Output for next step
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "head_ref=$HEAD_REF" >> $GITHUB_OUTPUT
+          echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
+          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger repository dispatch
+        timeout-minutes: 2
+        run: |
+          set -euo pipefail
+
           # Parse comment body for command
           COMMENT_BODY="${{ github.event.comment.body }}"
           SAFE_COMMENT=$(echo "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
@@ -147,10 +161,10 @@ jobs:
             --method POST \
             --field event_type='codebot-review' \
             --field client_payload="{
-              \"pr_number\": $PR_NUMBER,
-              \"head_ref\": \"$HEAD_REF\",
-              \"head_sha\": \"$HEAD_SHA\",
-              \"base_ref\": \"$BASE_REF\",
+              \"pr_number\": ${{ steps.pr-info.outputs.pr_number }},
+              \"head_ref\": \"${{ steps.pr-info.outputs.head_ref }}\",
+              \"head_sha\": \"${{ steps.pr-info.outputs.head_sha }}\",
+              \"base_ref\": \"${{ steps.pr-info.outputs.base_ref }}\",
               \"review_mode\": \"$MODE\",
               \"full_analysis\": \"$FULL_ANALYSIS\",
               \"comment_id\": \"${{ github.event.comment.id }}\",

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -159,7 +159,7 @@ jobs:
 
           echo "✅ Repository dispatch triggered successfully"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
   # Handle workflow_dispatch by creating a comment to trigger Claude
   dispatch-trigger:


### PR DESCRIPTION
## 🔧 Fix: Token Authentication Separation

This PR resolves the authentication issue discovered in workflow run #18050025292.

## 🚨 Problem  
After the previous fix enabled repository dispatch, the workflow failed with:
```
gh: Bad credentials (HTTP 401)
```

## 🔍 Root Cause
The same workflow step was using `CLAUDE_CODE_OAUTH_TOKEN` for both:
1. GitHub API calls (getting PR information) - ❌ Failed with 401
2. Repository dispatch - ✅ Worked correctly

## ✅ Solution
Split the step into two with appropriate token usage:

**Step 1: Get PR information**
```yaml
env:
  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # ✅ Works for GitHub API
```

**Step 2: Trigger repository dispatch**  
```yaml
env:
  GITHUB_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}  # ✅ Works for dispatch
```

## 🎯 Expected Result
With this fix, the codebot workflow should now:
1. ✅ Add 👀 eyes emoji to comments
2. ✅ Get PR information successfully  
3. ✅ Trigger repository dispatch successfully
4. ✅ Run Claude analysis and post comments

## 🧪 Next Steps
After merging, test with a new codebot comment to validate end-to-end functionality.