### PR TITLE
fix: restore two-workflow Claude pattern (@claude + codebot)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,37 +6,6 @@ on:
     types: [created]
   pull_request_review_comment:
     types: [created]
-  pull_request:
-    types: [opened, synchronize]
-
-  # Repository dispatch for correct branch context
-  repository_dispatch:
-    types: [codebot-review]
-
-  # Manual triggers via GitHub CLI
-  workflow_dispatch:
-    inputs:
-      review_mode:
-        description: 'Review mode to use'
-        required: false
-        default: 'hunt'
-        type: choice
-        options:
-          - hunt
-          - analyze
-          - security
-          - performance
-          - review
-      focus:
-        description: 'Focus areas (comma-separated)'
-        required: false
-        default: 'bugs,security,performance'
-        type: string
-      verbose:
-        description: 'Enable verbose output'
-        required: false
-        default: false
-        type: boolean
 
 jobs:
   # Add eyes reaction to show codebot is working
@@ -78,722 +47,77 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Handle workflow_dispatch by creating a comment to trigger Claude
-  dispatch-trigger:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Find open PR
-        id: find-pr
-        timeout-minutes: 3
-        run: |
-          set -euo pipefail  # Enhanced error handling
-
-          BRANCH_NAME="${{ github.ref_name }}"
-
-          # Validate branch name for security (allow underscores, dots, and forward slashes)
-          if ! [[ "$BRANCH_NAME" =~ ^[a-zA-Z0-9/_.-]+$ ]]; then
-            echo "Error: Invalid branch name format: $BRANCH_NAME"
-            exit 1
-          fi
-
-          echo "Searching for open PR for branch: $BRANCH_NAME"
-
-          # Find PR with error handling and validation
-          if ! PR_DATA=$(gh pr list --repo "${{ github.repository }}" --state open --head "$BRANCH_NAME" --json number --jq '.[0].number // empty' 2>/dev/null); then
-            echo "Error: Failed to query GitHub API for PRs"
-            exit 1
-          fi
-
-          if [ -z "$PR_DATA" ] || [ "$PR_DATA" = "null" ]; then
-            echo "No open PR found for branch $BRANCH_NAME"
-            exit 1
-          fi
-
-          # Validate PR number is numeric
-          if ! [[ "$PR_DATA" =~ ^[0-9]+$ ]]; then
-            echo "Error: Invalid PR number returned: $PR_DATA"
-            exit 1
-          fi
-
-          echo "Found PR #$PR_DATA"
-          echo "pr_number=$PR_DATA" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create trigger comment
-        timeout-minutes: 2
-        run: |
-          set -euo pipefail  # Enhanced error handling
-
-          PR_NUMBER="${{ steps.find-pr.outputs.pr_number }}"
-          REVIEW_MODE="${{ github.event.inputs.review_mode || 'hunt' }}"
-
-          # Validate inputs
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "Error: Invalid PR number: $PR_NUMBER"
-            exit 1
-          fi
-
-          # Validate review mode against allowed values
-          case "$REVIEW_MODE" in
-            hunt|analyze|security|performance|review)
-              echo "Using review mode: $REVIEW_MODE"
-              ;;
-            *)
-              echo "Error: Invalid review mode: $REVIEW_MODE"
-              exit 1
-              ;;
-          esac
-
-          # Build comment body safely
-          COMMENT_BODY="codebot $REVIEW_MODE"
-          if [ "${{ github.event.inputs.verbose }}" = "true" ]; then
-            COMMENT_BODY="$COMMENT_BODY verbose"
-          fi
-
-          echo "Creating comment: $COMMENT_BODY"
-
-          # Create comment with error handling
-          if ! gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$COMMENT_BODY"; then
-            echo "Error: Failed to create PR comment"
-            exit 1
-          fi
-
-          echo "Successfully created trigger comment on PR #$PR_NUMBER"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+  # Claude Code Action (using proven claude.yml pattern)
   claude:
-    # Run directly on codebot comments (simpler approach like claude.yml)
     if: |
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, 'codebot')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, 'codebot')) ||
-      (github.event_name == 'pull_request' && (
-        github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' ||
-        contains(github.event.pull_request.title, '[auto-review]')
-      ))
-
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, 'codebot'))
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # Prevent runaway executions
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: read
+      issues: read
       id-token: write
-      actions: read  # For Claude to read CI results
-      # Note: reactions permission is implicitly included in issues:write
-
-    env:
-      # Enable debug logging for GitHub API calls
-      ACTIONS_STEP_DEBUG: true
-      ACTIONS_RUNNER_DEBUG: true
-
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        # Pin to specific SHA for supply chain security (simple approach like claude.yml)
+        # Pin to specific SHA for supply chain security
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
-          fetch-depth: 0  # Full history for reliable diff comparisons
+          fetch-depth: 1
 
-
-      - name: Refresh git state
-        id: git-refresh
-        timeout-minutes: 3
-        run: |
-          set -euo pipefail
-
-          echo "🔄 Refreshing git state to ensure latest changes are analyzed"
-
-          # Get current branch name
-          CURRENT_BRANCH=$(git branch --show-current || echo "")
-          CURRENT_SHA=$(git rev-parse HEAD)
-
-          echo "Current branch: $CURRENT_BRANCH"
-          echo "Current SHA: $CURRENT_SHA"
-
-          # Fetch all remote references to ensure we have the latest state
-          echo "Fetching all remote references..."
-          git fetch --all --prune
-
-          # For repository dispatch or pull request events, ensure we have the latest changes
-          if [ "${{ github.event_name }}" = "repository_dispatch" ] || [ "${{ github.event_name }}" = "pull_request" ]; then
-            EXPECTED_SHA="${{ steps.checkout-ref.outputs.head_sha }}"
-            echo "Expected SHA: $EXPECTED_SHA"
-
-            # Fetch the specific branch to get latest changes
-            CHECKOUT_REF="${{ steps.checkout-ref.outputs.checkout_ref }}"
-            if [ -n "$CHECKOUT_REF" ]; then
-              echo "Fetching latest changes for ref: $CHECKOUT_REF"
-              git fetch origin "$CHECKOUT_REF" 2>/dev/null || true
-
-              # For branch refs, reset to the latest commit
-              if [[ "$CHECKOUT_REF" =~ ^refs/heads/ ]]; then
-                BRANCH_NAME="${CHECKOUT_REF#refs/heads/}"
-                echo "Resetting to latest commit on branch $BRANCH_NAME"
-                git reset --hard "origin/$BRANCH_NAME" 2>/dev/null || git reset --hard HEAD
-              elif [[ ! "$CHECKOUT_REF" =~ ^[a-f0-9]{40}$ ]]; then
-                # Not a full SHA, treat as branch name
-                echo "Resetting to latest commit on $CHECKOUT_REF"
-                git reset --hard "origin/$CHECKOUT_REF" 2>/dev/null || git reset --hard HEAD
-              fi
-
-              NEW_SHA=$(git rev-parse HEAD)
-              echo "Updated to SHA: $NEW_SHA"
-
-              if [ "$NEW_SHA" != "$CURRENT_SHA" ]; then
-                echo "⚠️  SHA changed from $CURRENT_SHA to $NEW_SHA - analyzing latest changes"
-              else
-                echo "✅ SHA unchanged - no new commits since checkout"
-              fi
-            fi
-          else
-            # For PR events, ensure we have the latest changes
-            if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "HEAD" ]; then
-              echo "Ensuring latest changes for branch: $CURRENT_BRANCH"
-              git fetch origin "$CURRENT_BRANCH" 2>/dev/null || true
-              git reset --hard "origin/$CURRENT_BRANCH" 2>/dev/null || git reset --hard HEAD
-
-              NEW_SHA=$(git rev-parse HEAD)
-              if [ "$NEW_SHA" != "$CURRENT_SHA" ]; then
-                echo "⚠️  SHA updated from $CURRENT_SHA to $NEW_SHA"
-              fi
-            fi
-          fi
-
-          # Final verification
-          FINAL_SHA=$(git rev-parse HEAD)
-          FINAL_BRANCH=$(git branch --show-current || echo "detached")
-
-          echo "✅ Git state refreshed successfully"
-          echo "Final branch: $FINAL_BRANCH"
-          echo "Final SHA: $FINAL_SHA"
-
-          # Output for use in subsequent steps
-          echo "current_sha=$FINAL_SHA" >> $GITHUB_OUTPUT
-          echo "current_branch=$FINAL_BRANCH" >> $GITHUB_OUTPUT
-
-
-      - name: Parse command configuration
-        id: parse-command
-        timeout-minutes: 2
-        run: |
-          set -euo pipefail
-
-          # Default values
-          echo "mode=hunt" >> $GITHUB_OUTPUT
-          echo "focus=bugs,security,performance" >> $GITHUB_OUTPUT
-          echo "verbose=false" >> $GITHUB_OUTPUT
-          echo "include_tests=true" >> $GITHUB_OUTPUT
-          echo "full_analysis=false" >> $GITHUB_OUTPUT
-
-          # Parse comment body for codebot commands
-          if [ "${{ github.event_name }}" = "issue_comment" ] || [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            COMMENT_BODY="${{ github.event.comment.body }}"
-            SAFE_COMMENT=$(echo "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
-
-            # Determine review mode
-            MODE="hunt"
-            if echo "$SAFE_COMMENT" | grep -qiF "codebot analyze"; then
-              MODE="analyze"
-            elif echo "$SAFE_COMMENT" | grep -qiF "codebot security"; then
-              MODE="security"
-            elif echo "$SAFE_COMMENT" | grep -qiF "codebot performance"; then
-              MODE="performance"
-            elif echo "$SAFE_COMMENT" | grep -qiF "codebot review"; then
-              MODE="review"
-            fi
-
-            # Check for full analysis flag
-            FULL_ANALYSIS="false"
-            if echo "$SAFE_COMMENT" | grep -qiF -- "--full"; then
-              FULL_ANALYSIS="true"
-            fi
-
-            echo "mode=$MODE" >> $GITHUB_OUTPUT
-            echo "full_analysis=$FULL_ANALYSIS" >> $GITHUB_OUTPUT
-
-            # Set focus and verbose based on mode
-            case "$MODE" in
-              hunt)
-                echo "focus=bugs,security,performance" >> $GITHUB_OUTPUT
-                echo "verbose=false" >> $GITHUB_OUTPUT
-                ;;
-              analyze)
-                echo "focus=architecture,patterns,complexity" >> $GITHUB_OUTPUT
-                echo "verbose=true" >> $GITHUB_OUTPUT
-                ;;
-              security)
-                echo "focus=security,vulnerabilities,compliance" >> $GITHUB_OUTPUT
-                echo "verbose=true" >> $GITHUB_OUTPUT
-                ;;
-              performance)
-                echo "focus=performance,optimization,bottlenecks" >> $GITHUB_OUTPUT
-                echo "verbose=true" >> $GITHUB_OUTPUT
-                ;;
-              review)
-                echo "focus=code-quality,security,performance" >> $GITHUB_OUTPUT
-                echo "verbose=true" >> $GITHUB_OUTPUT
-                ;;
-            esac
-
-            echo "Comment-based: mode=$MODE, full_analysis=$FULL_ANALYSIS"
-
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            # For pull_request events, use defaults or infer from title
-            if echo "${{ github.event.pull_request.title }}" | grep -qiF "[auto-review]"; then
-              echo "mode=review" >> $GITHUB_OUTPUT
-              echo "focus=code-quality,security,performance" >> $GITHUB_OUTPUT
-              echo "verbose=true" >> $GITHUB_OUTPUT
-              echo "full_analysis=false" >> $GITHUB_OUTPUT
-            fi
-
-            echo "Pull request event: using defaults or title-based inference"
-          fi
-
-      - name: Get PR information
-        id: pr-info
-        timeout-minutes: 3
-        run: |
-          set -euo pipefail
-
-          # Handle different trigger types with validation
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            PR_NUMBER="${{ github.event.issue.number }}"
-            # Get base ref from the PR
-            BASE_REF=$(gh api repos/${{ github.repository }}/pulls/$PR_NUMBER --jq '.base.ref')
-
-          elif [ "${{ github.event_name }}" = "pull_request_review_comment" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-
-          elif [ "${{ github.event_name }}" = "pull_request" ]; then
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-            BASE_REF="${{ github.event.pull_request.base.ref }}"
-
-          else
-            echo "Error: Unsupported event type: ${{ github.event_name }}"
-            exit 1
-          fi
-
-          # Validate required variables
-          if [ -z "$PR_NUMBER" ] || [ -z "$BASE_REF" ]; then
-            echo "Error: Missing required PR information"
-            echo "PR_NUMBER: $PR_NUMBER, BASE_REF: $BASE_REF"
-            exit 1
-          fi
-
-          # Validate PR number is numeric
-          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "Error: Invalid PR number: $PR_NUMBER"
-            exit 1
-          fi
-
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "base_ref=$BASE_REF" >> $GITHUB_OUTPUT
-          echo "✅ PR information validated: #$PR_NUMBER (base: $BASE_REF)"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get changed files
-        id: changes
-        if: steps.parse-command.outputs.full_analysis == 'false'
-        run: |
-
-          set -euo pipefail
-
-          BASE_REF="${{ steps.pr-info.outputs.base_ref }}"
-          CURRENT_SHA="${{ steps.git-refresh.outputs.current_sha }}"
-          CURRENT_BRANCH="${{ steps.git-refresh.outputs.current_branch }}"
-
-          echo "🔍 Detecting changed files for analysis"
-          echo "Base branch: $BASE_REF"
-          echo "Current SHA: $CURRENT_SHA"
-          echo "Current branch: $CURRENT_BRANCH"
-
-          # Ensure we have the base branch reference
-          echo "Fetching base branch: $BASE_REF"
-          git fetch origin "$BASE_REF" 2>/dev/null || {
-            echo "⚠️  Failed to fetch $BASE_REF, trying fallback methods"
-            git fetch origin 2>/dev/null || true
-          }
-
-          # Multiple fallback strategies for getting changed files
-          CHANGED_FILES=""
-          DIFF_SUCCESS=false
-
-          # Strategy 1: Standard three-dot diff (preferred)
-          if [ "$DIFF_SUCCESS" = false ]; then
-            echo "Trying three-dot diff: origin/$BASE_REF...HEAD"
-            if CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF...HEAD" 2>/dev/null); then
-              echo "✅ Three-dot diff successful"
-              DIFF_SUCCESS=true
-            else
-              echo "❌ Three-dot diff failed"
-            fi
-          fi
-
-          # Strategy 2: Two-dot diff fallback
-          if [ "$DIFF_SUCCESS" = false ]; then
-            echo "Trying two-dot diff: origin/$BASE_REF..HEAD"
-            if CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF..HEAD" 2>/dev/null); then
-              echo "✅ Two-dot diff successful"
-              DIFF_SUCCESS=true
-            else
-              echo "❌ Two-dot diff failed"
-            fi
-          fi
-
-          # Strategy 3: Direct branch comparison
-          if [ "$DIFF_SUCCESS" = false ]; then
-            echo "Trying direct comparison: origin/$BASE_REF HEAD"
-            if CHANGED_FILES=$(git diff --name-only "origin/$BASE_REF" HEAD 2>/dev/null); then
-              echo "✅ Direct comparison successful"
-              DIFF_SUCCESS=true
-            else
-              echo "❌ Direct comparison failed"
-            fi
-          fi
-
-          # Strategy 4: Last resort - use merge-base
-          if [ "$DIFF_SUCCESS" = false ]; then
-            echo "Trying merge-base approach"
-            if MERGE_BASE=$(git merge-base "origin/$BASE_REF" HEAD 2>/dev/null); then
-              if CHANGED_FILES=$(git diff --name-only "$MERGE_BASE" HEAD 2>/dev/null); then
-                echo "✅ Merge-base diff successful"
-                DIFF_SUCCESS=true
-              fi
-            fi
-          fi
-
-          # Validate and process results
-          if [ "$DIFF_SUCCESS" = false ]; then
-            echo "❌ All diff strategies failed - will analyze full codebase"
-            CHANGED_FILES=""
-            CHANGED_COUNT=0
-            CHANGED_FILES_STR="Unable to determine changed files - will analyze full codebase"
-          else
-            # Filter out empty lines and count
-            CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^$' || echo "")
-            CHANGED_COUNT=$(echo "$CHANGED_FILES" | grep -c . 2>/dev/null || echo "0")
-
-            if [ "$CHANGED_COUNT" -eq 0 ]; then
-              CHANGED_FILES_STR="No files changed"
-              echo "⚠️  No changed files detected - this might indicate an issue"
-            else
-              CHANGED_FILES_STR=$(echo "$CHANGED_FILES" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
-              echo "✅ Found $CHANGED_COUNT changed files"
-            fi
-          fi
-
-          # Debug output
-          echo "📋 Changed files summary:"
-          echo "  Count: $CHANGED_COUNT"
-          echo "  Files: $CHANGED_FILES_STR"
-
-
-          if [ "$CHANGED_COUNT" -gt 0 ]; then
-            echo "📄 Individual files:"
-            echo "$CHANGED_FILES" | while IFS= read -r file; do
-              [ -n "$file" ] && echo "  - $file"
-            done
-          fi
-
-          # Output for next steps
-          echo "changed_files=$CHANGED_FILES_STR" >> $GITHUB_OUTPUT
-          echo "changed_count=$CHANGED_COUNT" >> $GITHUB_OUTPUT
-          echo "diff_successful=$DIFF_SUCCESS" >> $GITHUB_OUTPUT
-
-      - name: Verify commit SHA and git state
-        id: verify-state
-        timeout-minutes: 2
-        run: |
-          set -euo pipefail
-
-          echo "🔍 Verifying git state before analysis"
-
-          CURRENT_SHA="${{ steps.git-refresh.outputs.current_sha }}"
-          ACTUAL_SHA=$(git rev-parse HEAD)
-          CURRENT_BRANCH="${{ steps.git-refresh.outputs.current_branch }}"
-
-          # Verify SHA consistency
-          if [ "$CURRENT_SHA" != "$ACTUAL_SHA" ]; then
-            echo "⚠️  SHA mismatch detected!"
-            echo "  Expected: $CURRENT_SHA"
-            echo "  Actual: $ACTUAL_SHA"
-            echo "  This indicates a git state issue - attempting to resolve..."
-
-            # Update the SHA for consistency
-            CURRENT_SHA="$ACTUAL_SHA"
-            echo "current_sha=$ACTUAL_SHA" >> $GITHUB_OUTPUT
-          else
-            echo "✅ SHA verification passed: $CURRENT_SHA"
-            echo "current_sha=$CURRENT_SHA" >> $GITHUB_OUTPUT
-          fi
-
-          # Get additional context for debugging
-          echo "📊 Git state summary:"
-          echo "  Commit SHA: $CURRENT_SHA"
-          echo "  Branch: $CURRENT_BRANCH"
-          echo "  Repository: ${{ github.repository }}"
-          echo "  Event: ${{ github.event_name }}"
-
-          # Get commit info for better context
-          COMMIT_MSG=$(git log -1 --pretty=format:"%s" 2>/dev/null || echo "Unable to get commit message")
-          COMMIT_AUTHOR=$(git log -1 --pretty=format:"%an" 2>/dev/null || echo "Unknown")
-          COMMIT_DATE=$(git log -1 --pretty=format:"%ci" 2>/dev/null || echo "Unknown")
-
-          echo "  Commit message: $COMMIT_MSG"
-          echo "  Author: $COMMIT_AUTHOR"
-          echo "  Date: $COMMIT_DATE"
-
-          # Create unique identifier for cache invalidation
-          REVIEW_ID="${CURRENT_SHA:0:8}-${{ github.event_name }}-$(date +%s)"
-          echo "  Review ID: $REVIEW_ID"
-
-          # Output additional context
-          echo "commit_message=$COMMIT_MSG" >> $GITHUB_OUTPUT
-          echo "commit_author=$COMMIT_AUTHOR" >> $GITHUB_OUTPUT
-          echo "commit_date=$COMMIT_DATE" >> $GITHUB_OUTPUT
-          echo "review_id=$REVIEW_ID" >> $GITHUB_OUTPUT
-
-      - name: Run Claude Code Review
+      - name: Run Claude Code
         id: claude
-        timeout-minutes: 10
         # Pin to specific version for supply chain security
         uses: anthropics/claude-code-action@v1.0.0
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: "codebot"
 
-          # Allow Claude to post comments and use MCP tools
-          allowed_tools: "mcp__github_comment__update_claude_comment,mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
 
-          # Dynamic prompt based on review mode
-          prompt: |
-            🔄 **COMMIT ANALYSIS CONTEXT**
-            - **Commit SHA**: `${{ steps.verify-state.outputs.current_sha }}`
-            - **Review ID**: `${{ steps.verify-state.outputs.review_id }}`
-            - **Branch**: `${{ steps.git-refresh.outputs.current_branch }}`
-            - **Last Commit**: "${{ steps.verify-state.outputs.commit_message }}" by ${{ steps.verify-state.outputs.commit_author }}
-            - **Date**: ${{ steps.verify-state.outputs.commit_date }}
+          # MCP Configuration for Terraform and Context7 documentation access
+          # Dependencies pinned to specific versions for supply chain security
+          mcp_config: |
+            {
+              "mcpServers": {
+                "terraform": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@modelcontextprotocol/server-terraform@0.6.0"
+                  ]
+                },
+                "context7": {
+                  "command": "npx",
+                  "args": [
+                    "-y",
+                    "@upstash/context7-mcp@1.0.0"
+                  ]
+                }
+              }
+            }
 
-            ---
+          # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
-            ${{ steps.parse-command.outputs.full_analysis == 'false' && format('
-            **IMPORTANT: Focus ONLY on the following changed files in this pull request:**
-            Files changed: {0}
-            Total files changed: {1}
-            Diff detection: {2}
+          # Subagent routing for specialized expertise
+          custom_instructions: |
+            You have access to specialized subagents for this Terraform AWS Cognito User Pool module. Use them for relevant questions:
 
-            DO NOT review or comment on files outside this list unless they are directly impacted by changes in these files.
-            ', steps.changes.outputs.changed_files || 'Unable to determine changed files', steps.changes.outputs.changed_count || '0', steps.changes.outputs.diff_successful == 'true' && 'Successful' || 'Failed - analyzing full codebase') || '' }}
+            **Subagent Routing Rules:**
+            - For Cognito User Pool configurations, resource setup, MFA, security features, authentication flows, identity providers: use @terraform-cognito
+            - For testing questions, Terratest, test development, validation, CI/CD testing: use @terraform-testing
+            - For security analysis, compliance, vulnerability assessment, hardening recommendations: use @terraform-security
+            - For migrations, upgrades, version transitions, breaking changes: use @cognito-migration
+            - For documentation, examples, README updates, user guides: use @module-documentation
 
-            ${{ steps.parse-command.outputs.mode == 'hunt' && format('
-            🕵️ BUG HUNT MODE - Find potential issues quickly:
-            - Focus on critical bugs, security vulnerabilities, and performance issues
-            - Prioritize high-impact problems over style suggestions
-            - Be concise and actionable
-            - Provide clear, actionable feedback
+            **Auto-routing Keywords:**
+            - MFA, authentication, password policy, advanced security → @terraform-security
+            - test, testing, terratest, validation, CI/CD → @terraform-testing
+            - migration, upgrade, version, breaking change → @cognito-migration
+            - user pool, client, domain, identity provider, schema → @terraform-cognito
+            - documentation, example, README, guide → @module-documentation
 
-            Use @terraform-cognito subagent for Cognito-specific issues, @terraform-security for security vulnerabilities
-            ') || '' }}
-
-            ${{ steps.parse-command.outputs.mode == 'analyze' && format('
-            📊 ANALYSIS MODE - Deep technical analysis:
-            - Analyze architecture, patterns, and design decisions
-            - Evaluate code complexity and maintainability
-            - Assess test coverage and quality
-            - Provide strategic recommendations
-            - Consider long-term implications and scalability
-
-            Use @terraform-testing subagent for test analysis, @terraform-cognito for architecture decisions
-            ') || '' }}
-
-            ${{ steps.parse-command.outputs.mode == 'security' && format('
-            🔒 SECURITY MODE - Security-focused review:
-            - Identify security vulnerabilities and compliance issues
-            - Check for proper authentication and authorization
-            - Validate input sanitization and output encoding
-            - Review encryption and key management
-            - Assess data protection and privacy concerns
-
-            Use @terraform-security subagent for comprehensive security analysis and hardening recommendations
-            ') || '' }}
-
-            ${{ steps.parse-command.outputs.mode == 'performance' && format('
-            ⚡ PERFORMANCE MODE - Performance optimization review:
-            - Identify performance bottlenecks and optimization opportunities
-            - Analyze resource usage and efficiency
-            - Check for memory leaks and scalability issues
-            - Review caching strategies and database queries
-            - Consider load testing and monitoring needs
-
-            Use @terraform-testing subagent for test performance and @terraform-cognito for Cognito performance optimization
-            ') || '' }}
-
-            ${{ steps.parse-command.outputs.mode == 'review' && format('
-            📝 STANDARD REVIEW MODE - Comprehensive code review:
-            - Code quality and best practices
-            - Potential bugs or issues
-            - Performance considerations
-            - Security concerns
-            - Test coverage and quality
-
-            Focus areas: {0}
-            Verbose output: {1}
-
-            Be constructive and helpful.
-
-            Use appropriate subagents: @terraform-cognito for Cognito configs, @terraform-security for security, @terraform-testing for tests
-            ', steps.parse-command.outputs.focus, steps.parse-command.outputs.verbose) || '' }}
-
-          # Enable sticky comments and progress tracking for visible analysis
-          use_sticky_comment: true
-          track_progress: true
-
-      - name: Direct API Isolation Test
-        if: always()
-        timeout-minutes: 2
-        run: |
-          set -euo pipefail
-
-          echo "🔬 Testing direct GitHub API comment posting to isolate permission issues"
-
-          PR_NUMBER="${{ steps.pr-info.outputs.pr_number }}"
-
-          # Test 1: Simple comment posting
-          echo "Test 1: Posting test comment via GitHub API"
-
-          COMMENT_BODY="🤖 **API Isolation Test Results**
-
-          **Claude Code Action Status**: Completed successfully
-          **Permission Test**: Testing direct API comment posting
-          **Timestamp**: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
-
-          If you see this comment, the GitHub API permissions are working correctly.
-          The issue may be within Claude Code Action's comment posting mechanism.
-
-          ---
-          *Generated by workflow debugging*"
-
-          # Use gh CLI to post comment (this uses GITHUB_TOKEN)
-          if gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" --repo "${{ github.repository }}"; then
-            echo "✅ SUCCESS: Direct API comment posting works!"
-            echo "🔍 This means the issue is within Claude Code Action's comment mechanism"
-          else
-            echo "❌ FAILED: Direct API comment posting failed"
-            echo "🔍 This indicates a fundamental token permission issue"
-            exit 1
-          fi
-
-          # Test 2: Check actual permissions
-          echo ""
-          echo "Test 2: Checking GitHub token permissions"
-          gh api user -H "Accept: application/vnd.github.v3+json" | jq -r '.login // "unknown"' || echo "Failed to get user info"
-
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Workflow Summary
-        if: always()
-        timeout-minutes: 2
-        run: |
-          set -euo pipefail  # Enhanced error handling
-
-          echo "## 🤖 Claude Code Review Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Security Status
-          echo "### 🔐 Security Status" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Input validation and sanitization enabled" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Command injection protection active" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Error handling and retry logic implemented" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Timeout protection for all operations" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Review Configuration
-          echo "### ⚙️ Review Configuration" >> $GITHUB_STEP_SUMMARY
-          echo "**Review Mode:** \`${{ steps.parse-command.outputs.mode }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Focus Areas:** \`${{ steps.parse-command.outputs.focus }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Verbose Output:** \`${{ steps.parse-command.outputs.verbose }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Full Analysis:** \`${{ steps.parse-command.outputs.full_analysis || 'false' }}\`" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.parse-command.outputs.full_analysis }}" != "true" ]; then
-            echo "**Changed Files:** \`${{ steps.changes.outputs.changed_count || '0' }}\` files" >> $GITHUB_STEP_SUMMARY
-            echo "**Diff Detection:** \`${{ steps.changes.outputs.diff_successful == 'true' && 'Successful' || 'Failed' }}\`" >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "**PR Number:** \`${{ steps.pr-info.outputs.pr_number || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Base Branch:** \`${{ steps.pr-info.outputs.base_ref || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Git State Information
-          echo "### 📊 Git State Analysis" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit SHA:** \`${{ steps.verify-state.outputs.current_sha || steps.git-refresh.outputs.current_sha || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Review ID:** \`${{ steps.verify-state.outputs.review_id || 'N/A' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Current Branch:** \`${{ steps.git-refresh.outputs.current_branch || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Last Commit:** \"${{ steps.verify-state.outputs.commit_message || 'Unknown' }}\"" >> $GITHUB_STEP_SUMMARY
-          echo "**Author:** \`${{ steps.verify-state.outputs.commit_author || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Date:** \`${{ steps.verify-state.outputs.commit_date || 'Unknown' }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Analysis Scope Details
-          if [ "${{ steps.parse-command.outputs.full_analysis }}" != "true" ] && [ "${{ steps.changes.outputs.changed_count || '0' }}" -gt "0" ]; then
-            echo "### 📄 Files Being Analyzed" >> $GITHUB_STEP_SUMMARY
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "${{ steps.changes.outputs.changed_files }}" | tr ' ' '\n' | grep -v '^$' | head -20 >> $GITHUB_STEP_SUMMARY
-            if [ "${{ steps.changes.outputs.changed_count }}" -gt "20" ]; then
-              echo "... and $((${{ steps.changes.outputs.changed_count }} - 20)) more files" >> $GITHUB_STEP_SUMMARY
-            fi
-            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-          fi
-
-          # Available Commands
-          echo "### 📝 Available Commands" >> $GITHUB_STEP_SUMMARY
-          echo "Comment any of these in PRs to trigger specific review types:" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot hunt\` - Quick bug detection (like Bugbot) on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot analyze\` - Deep technical analysis on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot security\` - Security-focused review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot performance\` - Performance optimization review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot review\` - Comprehensive review on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "- \`codebot\` - Defaults to hunt mode on PR changes" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Scope Options
-          echo "### 🔍 Scope Options" >> $GITHUB_STEP_SUMMARY
-          echo "- Add \`--full\` to any command to analyze the entire codebase" >> $GITHUB_STEP_SUMMARY
-          echo "- Example: \`codebot hunt --full\` - Hunt for bugs in the entire codebase" >> $GITHUB_STEP_SUMMARY
-          echo "- Default behavior (without --full) focuses only on changed files in the PR" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Manual Triggers
-          echo "### 🚀 Manual Triggers" >> $GITHUB_STEP_SUMMARY
-          echo "Run via GitHub CLI:" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`bash" >> $GITHUB_STEP_SUMMARY
-          echo "gh workflow run claude-code-review.yml -f review_mode=hunt" >> $GITHUB_STEP_SUMMARY
-          echo "gh workflow run claude-code-review.yml -f review_mode=security -f verbose=true" >> $GITHUB_STEP_SUMMARY
-          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
-
-          # Performance & Reliability Info
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### ⚡ Performance & Reliability" >> $GITHUB_STEP_SUMMARY
-          echo "- 🚀 Full git history fetch for reliable diff comparisons" >> $GITHUB_STEP_SUMMARY
-          echo "- 🔄 Automatic git state refresh and commit SHA verification" >> $GITHUB_STEP_SUMMARY
-          echo "- 🎯 Multiple fallback strategies for change detection" >> $GITHUB_STEP_SUMMARY
-          echo "- ⏱️ Timeout protection prevents runaway executions" >> $GITHUB_STEP_SUMMARY
-          echo "- 🛡️ Comprehensive error handling and validation" >> $GITHUB_STEP_SUMMARY
-          echo "- 📊 Enhanced logging and debug information" >> $GITHUB_STEP_SUMMARY
-          echo "- 🔐 Cache invalidation via commit-specific review IDs" >> $GITHUB_STEP_SUMMARY
-
-          # Troubleshooting section
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### 🔧 Troubleshooting" >> $GITHUB_STEP_SUMMARY
-          echo "If the review doesn't detect recent changes:" >> $GITHUB_STEP_SUMMARY
-          echo "1. Check the commit SHA matches your latest changes" >> $GITHUB_STEP_SUMMARY
-          echo "2. Verify the diff detection was successful" >> $GITHUB_STEP_SUMMARY
-          echo "3. Review the git state analysis above" >> $GITHUB_STEP_SUMMARY
-          echo "4. Try \`codebot hunt --full\` to analyze the entire codebase" >> $GITHUB_STEP_SUMMARY
+            Always leverage the specialized knowledge in these subagents for better, more accurate responses.


### PR DESCRIPTION
## Summary
Restore the proper two-workflow pattern for Claude integration, matching the terraform-aws-ecr repository structure.

## Two Distinct Workflows

### 1. claude.yml (unchanged)
- **Trigger**: `@claude` comments
- **Purpose**: General Claude assistance and questions
- **Events**: issue_comment, pull_request_review_comment, issues, pull_request_review

### 2. claude-code-review.yml (simplified)
- **Trigger**: `codebot` comments  
- **Purpose**: Automated code review with eyes emoji reactions
- **Features**: 
  - 👀 Eyes emoji reaction when codebot starts working
  - Claude Code Action analysis and comments
  - MCP integration for Terraform and Context7 docs
  - Subagent routing for specialized expertise

## Problem Fixed
Previously had complex debugging workflow that was posting debug output instead of actual Claude analysis. Now simplified to clean two-job approach:
1. `eyes-reaction` job: Posts 👀 emoji immediately 
2. `claude` job: Runs actual Claude Code Action analysis

## Pattern Consistency  
This matches the proven pattern from terraform-aws-ecr repository where:
- `@claude` = general assistance
- `codebot` = automated code review with visual feedback

## Testing
Ready for end-to-end testing on PRs #310 and #312 to verify both:
- Eyes emoji reactions work immediately
- Claude analysis comments post correctly

Fixes the codebot functionality while maintaining separate, clear purposes for each workflow.