### PR TITLE
fix: Update codebot trigger phrase to support mode commands

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -130,7 +130,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
           # Configure trigger phrase for codebot (support both formats)
-          trigger_phrase: "codebot"
+          trigger_phrase: "@codebot"
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
Fixes the Claude Code Action trigger mismatch that was preventing codebot from executing mode commands.

## Changes
- Change `trigger_phrase` from `"codebot"` to `"@codebot"` for exact matching
- Resolves issue where Claude Code Action wasn't triggering for mode commands like `codebot analyze`, `@codebot security`, etc.
- Job-level conditionals already handle both `@codebot` and `codebot` patterns
- Comment parsing regex already supports `@?codebot` pattern

## Root Cause
The Claude Code Action was configured with `trigger_phrase: "codebot"` which only matches exact "codebot" comments. Comments like "codebot analyze" or "@codebot security" didn't match this exact trigger, causing the action to skip execution.

## Test Plan
- [x] Applied fix in `.github/workflows/claude-code-review.yml`
- [x] Tested with `@codebot hunt --full` comment on PR #310
- [ ] Verify workflow triggers and posts analysis comments
- [ ] Test all 5 modes (hunt, analyze, security, performance, review)
- [ ] Confirm both `@codebot` and `codebot` formats work

## Related Issues
Resolves the trigger mismatch issue identified in PR #310 and #312 testing.