### PR TITLE
fix: Add write permissions for Claude Code Action to post comments

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,8 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write  # Required for Claude to post analysis comments
+      issues: write         # Required for Claude to post analysis comments
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
Fixes the missing write permissions that prevented Claude Code Action from posting analysis comments to PRs.

## Root Cause Analysis
From workflow run logs, Claude Code Action was:
- ✅ Triggering correctly
- ✅ Generating comprehensive analysis (1,712 tokens, detailed security report)
- ✅ Completing successfully
- ❌ **NOT posting comments** - missing write permissions

## Changes
- Change `pull-requests` permission from `read` to `write`
- Change `issues` permission from `read` to `write`
- Add comments explaining the permission requirements

## Before vs After
```yaml
# Before - could only read
permissions:
  pull-requests: read
  issues: read

# After - can post comments  
permissions:
  pull-requests: write  # Required for Claude to post analysis comments
  issues: write         # Required for Claude to post analysis comments
```

## Test Plan
- [x] Applied permissions fix
- [ ] Merge and test with new `@codebot` comment
- [ ] Verify analysis comments appear in PRs
- [ ] Confirm all modes still work (hunt, security, analyze, performance, review)

## Related Issues
Resolves the comment posting issue discovered in PR #310 and #312 testing where Claude was generating analysis but comments weren't appearing.