### PR TITLE
fix: Remove unsupported allowed_tools parameter from Claude Code Action v1.0.0

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -155,9 +155,6 @@ jobs:
               }
             }
 
-          # Allow MCP tools for documentation access - required for comment posting
-          allowed_tools: "mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
-
           # Dynamic prompt based on parsed mode
           prompt: |
             🤖 **CODEBOT ${{ steps.parse-command.outputs.mode || 'HUNT' }} MODE** - Terraform AWS Cognito User Pool Module


### PR DESCRIPTION
## Critical Fix - Comment Posting Issue

### Problem 
The codebot was generating analysis successfully but NOT posting comments. Investigation revealed the issue:

```
##[warning]Unexpected input(s) 'allowed_tools', valid inputs are ['trigger_phrase', 'assignee_trigger', 'label_trigger', ...]
```

### Root Cause
The `allowed_tools` parameter **does not exist** in Claude Code Action v1.0.0. This invalid parameter was causing the entire configuration to fail silently, preventing comment posting even though analysis was being generated.

### Evidence from Logs
✅ **Analysis Generated**: Full bug hunt results visible in workflow logs  
❌ **Comments Not Posted**: Invalid configuration prevented posting  
⚠️  **Warning Generated**: "Unexpected input(s) 'allowed_tools'"

### Solution
Remove the unsupported `allowed_tools` parameter. Claude Code Action v1.0.0 has its own internal mechanism for comment posting that doesn't require this parameter.

### Testing
After this fix, the codebot should:
- ✅ Generate analysis (already working)  
- ✅ Post analysis as comments (should now work)
- ✅ Support all 5 modes (hunt, security, analyze, performance, review)

This is the final piece needed for full codebot functionality.