### PR TITLE
fix: Fix comment parsing to prevent bash command execution

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -73,7 +73,7 @@ jobs:
 
           # Get comment body safely
           COMMENT_BODY="${{ github.event.comment.body }}"
-          SAFE_COMMENT=$(echo "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
+          SAFE_COMMENT=$(printf '%s' "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
 
           echo "Parsing comment: $SAFE_COMMENT"
 


### PR DESCRIPTION
## Problem
The codebot workflow was failing with 'command not found' errors when processing comments containing backticks (like `allowed_tools`). The issue was in the comment parsing step where echo was executing words as commands.

## Solution
- Replace echo with printf for safer comment text handling
- Prevents bash from trying to execute words like 'allowed_tools' as commands
- Fixes the 'command not found' error when processing comments with code syntax
- Maintains same text filtering and safety measures

## Testing
This should resolve the bash parsing error seen in recent workflow runs where allowed_tools was being treated as a command.

Fixes the codebot comment posting functionality.