### PR TITLE
fix: Use environment variable for comment body to prevent command injection

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -68,11 +68,12 @@ jobs:
 
       - name: Parse codebot command
         id: parse-command
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
         run: |
           set -euo pipefail
 
-          # Get comment body safely
-          COMMENT_BODY="${{ github.event.comment.body }}"
+          # Get comment body safely from environment variable
           SAFE_COMMENT=$(printf '%s' "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
 
           echo "Parsing comment: $SAFE_COMMENT"


### PR DESCRIPTION
## Security Fix

This PR addresses a command injection vulnerability in the codebot workflow.

## Problem
The comment body was being directly interpolated into bash scripts using `${{ github.event.comment.body }}`, which meant any words in user comments could be executed as bash commands, causing errors like:
- `backticks: command not found`
- `allowed_tools: command not found`

## Solution
- Move comment body to environment variable (`env: COMMENT_BODY`)
- Access via `$COMMENT_BODY` instead of direct interpolation
- Prevents GitHub Actions from injecting user input directly into bash script
- Maintains same text filtering and safety measures

## Security Impact
This prevents potential command injection attacks where malicious comments could execute arbitrary bash commands in the workflow environment.

Fixes the remaining bash parsing errors in the codebot workflow.