### PR TITLE
fix: correct Claude Code Action parameters for codebot commenting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -156,13 +156,15 @@ jobs:
             }
 
           # Required tool permissions for GitHub commenting (v1.0 format)
-          claude_args: |
-            --allowedTools "Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          allowed_tools: "Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+
+          # Set trigger phrase for codebot mentions
+          trigger_phrase: "codebot"
 
           # Dynamic prompt based on parsed mode
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
             COMMENT: ${{ github.event.comment.body }}
 
             🤖 **CODEBOT ${{ steps.parse-command.outputs.mode || 'HUNT' }} MODE** - Terraform AWS Cognito User Pool Module
@@ -265,3 +267,5 @@ jobs:
             - **@module-documentation**: Documentation, examples, README updates, user guides
 
             Always leverage the specialized knowledge in these subagents for better, more accurate responses.
+
+            **CRITICAL FINAL INSTRUCTION**: After completing your analysis, post your complete findings as a comment on this pull request using the GitHub commenting tools available to you.


### PR DESCRIPTION
## Problem
The codebot workflow (claude-code-review.yml) was completing successfully but not posting analysis comments. The eyes emoji reactions worked, but Claude wasn't commenting back with analysis.

## Root Cause Analysis
Based on Claude Code Action documentation research:

1. **Wrong Parameter Format**: Using `claude_args: | --allowedTools` instead of `allowed_tools: "string"`
2. **Missing Trigger Bridge**: Workflow detected "codebot" mentions but Claude expected its trigger phrase
3. **GitHub Context Issues**: Using `github.event.pull_request.number` in comment events where it may not exist
4. **No Explicit Comment Instruction**: Custom prompt didn't tell Claude to post a comment

## Solution Applied

### ✅ Fixed Parameter Format
- Replaced `claude_args: | --allowedTools` with `allowed_tools: "string"` (v1.0 format)
- Matches working claude.yml pattern

### ✅ Added Trigger Phrase
- Added `trigger_phrase: "codebot"` to make Claude respond to codebot mentions
- Bridges the gap between "codebot" detection and Claude's natural behavior

### ✅ Fixed GitHub Context
- Changed `github.event.pull_request.number` to `github.event.issue.number || github.event.pull_request.number`
- Handles both issue comments and PR review comments correctly

### ✅ Added Comment Instruction
- Added explicit instruction: "After completing your analysis, post your complete findings as a comment on this pull request"
- Ensures Claude knows to comment, not just analyze

## Expected Behavior After Fix
- ✅ Eyes emoji reactions (already working)
- ✅ Claude analysis comments (now fixed)
- ✅ Sophisticated modes (hunt, security, analyze, performance, review)
- ✅ Subagent routing for specialized expertise

## Testing Plan
1. Merge this PR
2. Test with simple "codebot" comment on a PR
3. Verify both eyes emoji AND analysis comment appear
4. Test different modes: "codebot security", "codebot analyze", etc.

Fixes the core issue where codebot workflow ran successfully but didn't post comments due to Claude Code Action v1.0 parameter format requirements.