### PR TITLE
fix: use claude_args instead of unrecognized allowed_tools parameter

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -156,7 +156,7 @@ jobs:
             }
 
           # Required tool permissions for GitHub commenting (v1.0 format)
-          allowed_tools: "Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          claude_args: "--allowedTools Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Set trigger phrase for codebot mentions
           trigger_phrase: "codebot"


### PR DESCRIPTION
## Problem
The codebot workflow was still not posting comments despite the previous fix. Investigation of the workflow logs revealed a critical issue:

```
##[warning]Unexpected input(s) 'allowed_tools', valid inputs are ['trigger_phrase', 'assignee_trigger', 'label_trigger', ...]
```

The `allowed_tools` parameter is **not recognized** by Claude Code Action v1.0.0, which means Claude didn't have access to the GitHub commenting tools.

## Root Cause
- Claude Code Action v1.0.0 doesn't support `allowed_tools` as a direct parameter
- The valid inputs list shows `claude_args` is the correct way to pass tool permissions
- Without proper tool permissions, Claude can't post comments even with explicit instructions

## Solution
- Changed from `allowed_tools: "..."` to `claude_args: "--allowedTools ..."`
- This matches the format expected by Claude Code Action v1.0.0
- Follows the action's documented parameter structure

## Expected Result
Now that Claude will have proper access to GitHub commenting tools (`gh pr comment`, `gh api`), it should be able to post analysis comments as instructed by the prompt.

## Testing
This PR will be merged and tested with another codebot comment to verify the fix works.