### PR TITLE
fix: correct MCP server tool names in GitHub Actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -156,7 +156,7 @@ jobs:
             }
 
           # Required tool permissions for GitHub commenting (v1.0 format)
-          claude_args: "--allowedTools Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          claude_args: "--allowedTools Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Set trigger phrase for codebot mentions
           trigger_phrase: "codebot"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,7 +65,7 @@ jobs:
             }
 
           # Allow Bash permissions for pre-commit hooks and documentation updates + MCP tools
-          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__getProviderDocs,mcp__terraform-server__resolveProviderDocID,mcp__terraform-server__searchModules,mcp__terraform-server__moduleDetails,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          allowed_tools: "Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"


### PR DESCRIPTION
## Summary
Fixes permission denied errors when Claude tries to use MCP servers in GitHub Actions by correcting the tool names in `allowed_tools` configurations.

## Problem
Claude was encountering "Permission denied" errors when attempting to use Terraform MCP server tools in GitHub Actions, despite successful local testing. The issue was a mismatch between the configured tool names and the actual function signatures.

## Root Cause
The `allowed_tools` configuration used outdated or incorrect function names:
- `mcp__terraform-server__getProviderDocs` (incorrect)
- `mcp__terraform-server__resolveProviderDocID` (incorrect)
- `mcp__terraform-server__searchModules` (incorrect)
- `mcp__terraform-server__moduleDetails` (incorrect)

## Solution
Updated both workflow files with the correct MCP tool function names:
- `mcp__terraform-server__get_provider_details` ✅
- `mcp__terraform-server__search_providers` ✅
- `mcp__terraform-server__search_modules` ✅
- `mcp__terraform-server__get_module_details` ✅

## Files Changed
- `.github/workflows/claude.yml` - Updated `allowed_tools` parameter
- `.github/workflows/claude-code-review.yml` - Updated `claude_args` parameter

## Testing
- ✅ Pre-commit hooks passed
- ✅ MCP tool function names verified through local testing
- ✅ Context7 MCP server tools remain unchanged (already correct)

## Expected Impact
After this fix, Claude should be able to successfully:
- Validate `ALLOW_ADMIN_USER_PASSWORD_AUTH` and other Cognito parameters
- Access Terraform AWS provider documentation via MCP server
- Provide accurate validation for explicit_auth_flows configurations
- Function properly in both @claude and codebot workflows

## Related Issues
Resolves the "Permission denied" error when Claude attempts to use MCP servers for Terraform documentation lookup in GitHub Actions environment.