### PR TITLE
chore: fix trailing whitespace in security_test.go

### DIFF
--- a/test/integration/security_test.go
+++ b/test/integration/security_test.go
@@ -369,15 +369,15 @@ func TestTerraformCognitoRefreshTokenRotation(t *testing.T) {
 		// Validate client configuration by describing the client
 		for _, clientID := range clientIDs {
 			userPoolClient := helpers.ValidateUserPoolClientExists(t, client, userPoolID, clientID)
-			
+
 			// Validate that token revocation is enabled (related to refresh token rotation)
 			assert.NotNil(t, userPoolClient.EnableTokenRevocation)
 			assert.True(t, *userPoolClient.EnableTokenRevocation, "Token revocation should be enabled for refresh token rotation")
-			
+
 			// Validate token validity settings
 			assert.NotNil(t, userPoolClient.AccessTokenValidity)
 			assert.Equal(t, int32(60), *userPoolClient.AccessTokenValidity)
-			
+
 			assert.NotNil(t, userPoolClient.RefreshTokenValidity)
 			assert.Equal(t, int32(30), *userPoolClient.RefreshTokenValidity)
 		}


### PR DESCRIPTION
## Summary
Fixes trailing whitespace found by pre-commit hook during PR #354 merge.

## Changes
- Removed trailing whitespace from lines 371, 376, and 380 in `test/integration/security_test.go`

## Context
The pre-commit hook detected trailing whitespace when PR #354 was merged to master:
https://github.com/lgallard/terraform-aws-cognito-user-pool/actions/runs/18481276023/job/52656273521

## Validation
- ✅ Pre-commit hooks passed locally
- ✅ No functional changes, only whitespace cleanup