### PR TITLE
fix: correct spacing in README module description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Terraform](https://lgallardo.com/images/terraform.jpg)
 # terraform-aws-cognito-user-pool
 
-Terraform module to create [Amazon Cognito User Pools](https://aws.amazon.com/cognito/), configure its attributes and resources such as  **app clients**, **domain**, **resource servers**. Amazon Cognito User Pools provide a secure user directory that scales to hundreds of millions of users. As a fully managed service, User Pools are easy to set up without any worries about standing up server infrastructure.
+Terraform module to create [Amazon Cognito User Pools](https://aws.amazon.com/cognito/), configure its attributes and resources such as **app clients**, **domain**, **resource servers**. Amazon Cognito User Pools provide a secure user directory that scales to hundreds of millions of users. As a fully managed service, User Pools are easy to set up without any worries about standing up server infrastructure.
 
 ## Usage
 


### PR DESCRIPTION
## Description
Fix double spacing in README module description.

## Type of Change
- [ ] Documentation update
- [x] Bug fix
- [ ] Feature

## Testing
This is a Phase 2 test of release-please automation - verifying that `fix:` commits trigger release PR creation.

**Expected behavior**: Release-please should create a PR for version 3.1.1 after this is merged.