### PR TITLE
fix: improve identity provider validation error message clarity

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -995,7 +995,7 @@ variable "identity_providers" {
       for provider in var.identity_providers :
       can(provider.provider_name) && can(provider.provider_type)
     ])
-    error_message = "Each identity provider must have provider_name and provider_type defined."
+    error_message = "Each identity provider must have provider_name and provider_type defined. These are required fields for AWS Cognito identity provider configuration."
   }
 }
 


### PR DESCRIPTION
Enhances the validation error message for the `identity_providers` variable to provide clearer guidance about AWS Cognito requirements.

## Changes
- Improved error message for `identity_providers` validation to be more descriptive and helpful

## Context
This fix commit will trigger release-please to create release 3.1.2, which will include:
- This validation message improvement
- Phase 4 refactoring changes from PR #365

## Related
- Follows up on PR #365 (Phase 4 modernization)