### PR TITLE
fix: enable GitHub MCP tools for codebot comment posting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -157,7 +157,8 @@ jobs:
 
           # Required tool permissions for GitHub commenting (v1.0 format)
           # Task: enables subagent invocation | Read/Grep/Glob: enables code examination
-          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh api:*),mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          # mcp__github__*: enables GitHub comment posting via MCP tools
+          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh api:*),mcp__github__*,mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Set trigger phrase for codebot mentions
           trigger_phrase: "codebot"


### PR DESCRIPTION
## Summary
Fixes codebot's inability to post analysis comments to PRs by enabling the required GitHub MCP tools.

## Problem Analysis
Workflow run [18860160762](https://github.com/lgallard/terraform-aws-cognito-user-pool/actions/runs/18860160762) revealed:

✅ **Working**: Subagent delegation is functioning correctly (Task tool successfully invoked specialized agents)

❌ **Broken**: Comment posting failed with permission error:
```
"Claude requested permissions to use mcp__github_comment__update_claude_comment, but you haven't granted it yet."
```

The codebot completed the full analysis (visible in workflow summary) but couldn't post results to the PR.

## Changes
- Add `mcp__github__*` to allowed tools in `claude_args`
- Add explanatory comment for the new permission grant

## Root Cause
PR #373 enabled Task/Read/Grep/Glob tools for subagent delegation, but missed the GitHub MCP tools needed for comment posting. Codebot tried to use `mcp__github_comment__update_claude_comment` which wasn't in the allowed list.

## Testing Plan
After merging, trigger `@codebot hunt` on PR #369 to verify:
1. Subagent delegation continues working
2. Analysis comment successfully posts to PR
3. No permission errors in workflow logs

## Related
- Follows up on PR #373 (subagent enablement)
- Resolves comment posting issues discovered in testing