### PR TITLE
fix: correct GitHub MCP server tool names for comment posting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -157,8 +157,8 @@ jobs:
 
           # Required tool permissions for GitHub commenting (v1.0 format)
           # Task: enables subagent invocation | Read/Grep/Glob: enables code examination
-          # mcp__github__*: enables GitHub comment posting via MCP tools
-          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh api:*),mcp__github__*,mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
+          # mcp__github_comment__*: enables GitHub comment posting | mcp__github_ci__*: enables CI status checks
+          claude_args: "--allowedTools Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh api:*),mcp__github_comment__*,mcp__github_ci__*,mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs"
 
           # Set trigger phrase for codebot mentions
           trigger_phrase: "codebot"


### PR DESCRIPTION
## Summary
Fixes the actual root cause of codebot's comment posting failure by using the correct MCP server tool names.

## Problem Analysis
PR #375 added `mcp__github__*` but this wildcard **doesn't match** the actual server names provided by `claude-code-action@v1.0.0`.

### Actual MCP Server Names
From workflow run [18860688176](https://github.com/lgallard/terraform-aws-cognito-user-pool/actions/runs/18860688176) logs:
```json
{
  "mcpServers": {
    "github_comment": {...},  // → mcp__github_comment__*
    "github_ci": {...}         // → mcp__github_ci__*
  }
}
```

### Permission Error
```
"Claude requested permissions to use mcp__github_comment__update_claude_comment, 
 but you haven't granted it yet."
```

The wildcard `mcp__github__*` does NOT match `mcp__github_comment__*` because the server name is `github_comment`, not `github`.

## Changes
- Replace `mcp__github__*` with explicit `mcp__github_comment__*`
- Add `mcp__github_ci__*` for CI status check capabilities
- Update inline comment to reflect actual permissions

## Verification from Logs
Workflow run 18860688176 showed:
- ✅ Subagent delegation working (Task tool used successfully)
- ✅ Analysis completed (full output in workflow summary)
- ✅ Comment body generated successfully
- ❌ Posting blocked by permission error

## Testing Plan
After merging:
1. Trigger `@codebot hunt` on PR #369
2. Verify analysis comment posts successfully
3. Confirm no permission errors in workflow logs
4. Validate subagent delegation still works

## Related
- Supersedes PR #375 (fixed wildcard pattern incorrectly)
- Follows up on PR #373 (subagent enablement)