### PR TITLE
fix: use empty list instead of null for lambda_config when not configured

### DIFF
--- a/locals-lambda.tf
+++ b/locals-lambda.tf
@@ -27,5 +27,5 @@ locals {
 
   lambda_config = (
     var.lambda_config == null || length(var.lambda_config) == 0
-  ) ? null : [local.lambda_config_default]
+  ) ? [] : [local.lambda_config_default]
 }


### PR DESCRIPTION
This resolves the 'Cannot use a null value in for_each' error introduced in v3.1.5 when lambda_config is not provided or empty. The dynamic lambda_config blocks in both user pool resources now receive an empty list instead of null, allowing for_each to work correctly.

Fixes #385

Generated with [Claude Code](https://claude.ai/code)