### PR TITLE
Change password_policy_minimum_length

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -483,8 +483,8 @@ variable "password_policy_minimum_length" {
   default     = 8
 
   validation {
-    condition     = var.password_policy_minimum_length >= 8 && var.password_policy_minimum_length <= 99
-    error_message = "Password minimum length must be between 8 and 99 characters for security (legacy variable validation)."
+    condition     = var.password_policy_minimum_length >= 6 && var.password_policy_minimum_length <= 99
+    error_message = "Password minimum length must be between 6 and 99 characters for security (legacy variable validation)."
   }
 }
 


### PR DESCRIPTION
It turned out to be problematic for our partners to have a minimum of 8 characters, so I ask you to change the minimum number to 6. I hope someone has encountered this and is there a workaround to specify 6 characters?