### PR TITLE
fix: pass through ui_customization_css/image_file in clients_parsed

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -103,9 +103,11 @@ locals {
       e.prevent_user_existence_errors,
       try(e.client_prevent_user_existence_errors, null)
     )
-    write_attributes        = try(e.write_attributes, null)
-    enable_token_revocation = try(e.enable_token_revocation, null)
-    refresh_token_rotation  = try(e.refresh_token_rotation, {})
+    write_attributes            = try(e.write_attributes, null)
+    enable_token_revocation     = try(e.enable_token_revocation, null)
+    refresh_token_rotation      = try(e.refresh_token_rotation, {})
+    ui_customization_css        = try(e.ui_customization_css, null)
+    ui_customization_image_file = try(e.ui_customization_image_file, null)
     }
   ]
 


### PR DESCRIPTION
Per-client ui_customization_css and ui_customization_image_file passed via the clients input were silently dropped because clients_parsed in client.tf rebuilt each client object explicitly without these fields. After PR #378 switched ui-customization.tf to iterate local.clients instead of var.clients, the filter saw null for both fields and excluded every entry, so aws_cognito_user_pool_ui_customization was never created.

Add the two fields to clients_parsed so they reach local.clients and the existing downstream logic in ui-customization.tf works as documented. The official examples/complete uses this pattern and now creates the expected resource.

Fixes #394