### PR TITLE
fix: align `clients_default` with `clients_parsed` to fix ternary types

### DIFF
--- a/client.tf
+++ b/client.tf
@@ -77,6 +77,8 @@ locals {
       write_attributes                              = var.client_write_attributes
       enable_token_revocation                       = var.client_enable_token_revocation
       refresh_token_rotation                        = var.client_refresh_token_rotation
+      ui_customization_css                          = null
+      ui_customization_image_file                   = null
     }
   ]
 


### PR DESCRIPTION
PR #395 added `ui_customization_css` and `ui_customization_image_file` to `local.clients_parsed` but did not add them to `local.clients_default`. Terraform's ternary in `local.clients` now sees two object types with different field sets, causing "Inconsistent conditional result types" errors when `var.clients` is used and the ternary's type unification fails:

  local.clients = ... ? local.clients_parsed : local.clients_default

Add the same two fields to `clients_default` with `null` values. There are no top-level legacy `var.client_ui_customization_*` variables, and single-client mode previously did not support per-client UI customization, so `null` preserves existing behavior while restoring type compatibility between the two branches.