### PR TITLE
fix: release Terraform refactor commits

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -4,7 +4,25 @@
       "release-type": "terraform-module",
       "changelog-path": "CHANGELOG.md",
       "include-v-in-tag": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "Features"
+        },
+        {
+          "type": "fix",
+          "section": "Bug Fixes"
+        },
+        {
+          "type": "perf",
+          "section": "Performance Improvements"
+        },
+        {
+          "type": "refactor",
+          "section": "Code Refactoring"
+        }
+      ]
     }
   },
   "pull-request-title-pattern": "chore: release ${version}"


### PR DESCRIPTION
## Summary
- Include `refactor` in release-please changelog sections for Terraform module releases
- Keep honest `refactor:` commit usage while still publishing implementation refactors as patch releases for pinned module users
- Ensures the already-merged Phase 5 security modernization refactor is considered releasable by release-please

Closes #407

## Why
Terraform module source is the distributed artifact. If implementation refactors land on `master` without a tag, users pinned to Terraform Registry versions or Git tags do not receive them.

## Test Plan
- `python3 -m json.tool .release-please-config.json`
- `pre-commit run --files .release-please-config.json`
