### PR TITLE
fix: ignore Apple `private_key` and Google auto-populated `provider_details` keys (perpetual IdP drift)

### DIFF
--- a/identity-provider.tf
+++ b/identity-provider.tf
@@ -19,15 +19,19 @@ resource "aws_cognito_identity_provider" "identity_provider" {
       # SAML provider auto-managed fields
       provider_details["ActiveEncryptionCertificate"],
 
-      # OAuth provider auto-managed fields that may cause drift
-      provider_details["authorize_url"], # May be updated via OIDC discovery
-      provider_details["token_url"],     # May be updated via OIDC discovery
-      provider_details["oidc_issuer"],   # May be updated via OIDC discovery
-      provider_details["jwks_uri"],      # Auto-populated from OIDC discovery
-      provider_details["issuer"],        # May be auto-populated
+      # OAuth/OIDC provider auto-managed fields that may cause drift
+      provider_details["authorize_url"],                 # May be updated via OIDC discovery
+      provider_details["token_url"],                     # May be updated via OIDC discovery
+      provider_details["oidc_issuer"],                   # May be updated via OIDC discovery
+      provider_details["jwks_uri"],                      # Auto-populated from OIDC discovery
+      provider_details["issuer"],                        # May be auto-populated
+      provider_details["attributes_url"],                # Auto-populated on read (e.g. Google)
+      provider_details["attributes_url_add_attributes"], # Auto-populated on read (e.g. Google)
+      provider_details["token_request_method"],          # Auto-populated on read (e.g. Google)
 
-      # Sensitive fields that cause drift due to Terraform's sensitive value handling
+      # Sensitive / write-only fields that cause drift due to Terraform's handling
       provider_details["client_secret"], # Sensitive field causing plan drift
+      provider_details["private_key"],    # SignInWithApple: write-only, never returned by AWS
     ]
   }
 }


### PR DESCRIPTION
## Problem

`aws_cognito_identity_provider` still shows a perpetual no-op `provider_details`
update on `terraform plan` for some provider types, even after #176 (SAML
`ActiveEncryptionCertificate`) and #371 (OAuth `client_secret` + OIDC discovery
URLs). The current `ignore_changes` list misses two cases:

1. **`SignInWithApple` — `private_key`.** It is write-only; AWS never returns it
   on read, so Terraform plans to re-set it on every run. It is not in the list
   at all, so every Apple provider drifts forever.

2. **Google (and other OIDC-style) providers — extra auto-populated keys.** On
   read, AWS populates `attributes_url`, `attributes_url_add_attributes` and
   `token_request_method` in addition to the discovery URLs already ignored.
   These are not user-supplied, so they show as drift on every plan.

Both are the same class of issue #176/#371 already address: AWS-managed or
write-only fields that the practitioner never sets but that reappear in the
read. This just extends the existing list to cover them.

## Change

Add to the `lifecycle.ignore_changes` block in `identity-provider.tf`:

```hcl
provider_details["attributes_url"]                # Google/OIDC, auto-populated on read
provider_details["attributes_url_add_attributes"] # Google/OIDC, auto-populated on read
provider_details["token_request_method"]          # Google/OIDC, auto-populated on read
provider_details["private_key"]                   # SignInWithApple, write-only / never returned
```

No change to resource creation or to any value the practitioner sets
(`client_id`, `authorize_scopes`, `team_id`, `key_id`, `attribute_mapping`,
etc. are still tracked) — purely drift suppression on AWS-managed/write-only
keys, consistent with the keys already ignored.

## Scope / known limitation

This fixes the perpetual diff for **Google/OIDC** and **SignInWithApple**
providers. **SAML** providers may still show residual `provider_details` drift
from other AWS-extracted fields (e.g. binding URLs derived from the uploaded
metadata); those are intentionally left out of this PR because some are
practitioner-managed (`MetadataFile`) and ignoring them would silently drop
legitimate metadata updates. Happy to follow up on SAML separately if there's a
confirmed safe key set.

## Testing

`terraform plan` against a user pool with a `SignInWithApple` provider and a
`Google` provider shows no `provider_details` changes after apply (previously a
perpetual in-place update on both).
