### PR TITLE
fix: ignore Apple private_key and Google auto-populated provider_details keys

### DIFF
--- a/identity-provider.tf
+++ b/identity-provider.tf
@@ -25,9 +25,13 @@ resource "aws_cognito_identity_provider" "identity_provider" {
       provider_details["oidc_issuer"],   # May be updated via OIDC discovery
       provider_details["jwks_uri"],      # Auto-populated from OIDC discovery
       provider_details["issuer"],        # May be auto-populated
+      provider_details["attributes_url"],
+      provider_details["attributes_url_add_attributes"],
+      provider_details["token_request_method"],
 
       # Sensitive fields that cause drift due to Terraform's sensitive value handling
       provider_details["client_secret"], # Sensitive field causing plan drift
+      provider_details["private_key"],
     ]
   }
 }


### PR DESCRIPTION
## Problem

`aws_cognito_identity_provider` shows a perpetual no-op `provider_details`
update on `terraform plan` for **Google** and **SignInWithApple** providers:

- **SignInWithApple — `private_key`**: write-only; AWS never returns it on read,
  so Terraform plans to re-set it on every run.
- **Google — `attributes_url`, `attributes_url_add_attributes`,
  `token_request_method`**: AWS auto-populates these on read; the practitioner
  never sets them, so they show as drift on every plan.

Both are the same class of AWS-managed / write-only field the list already
covers for `client_secret`, the OIDC discovery URLs and the SAML
`ActiveEncryptionCertificate`.

## Change

Four keys appended to the existing `lifecycle.ignore_changes` block. **Additive
only** — no existing line, comment or alignment is touched, and `terraform fmt`
is clean. No value a practitioner sets (`client_id`, `team_id`, `key_id`,
`attribute_mapping`, …) stops being tracked.

## Testing

`terraform plan` against real Google and SignInWithApple providers: the
perpetual in-place `provider_details` update is **gone (0 changes)** after this,
where before every such provider drifted on every plan.

## Scope

SAML providers can still show residual `provider_details` drift from
metadata-derived fields; those are intentionally left out of this PR — some
(e.g. `MetadataFile`) are practitioner-managed and ignoring them would silently
drop legitimate updates.

Supersedes #415 with a minimal, additive-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
