### PR TITLE
fix: ignore AWS-derived SAML SSORedirectBindingURI to prevent perpetual drift

### DIFF
--- a/identity-provider.tf
+++ b/identity-provider.tf
@@ -18,6 +18,7 @@ resource "aws_cognito_identity_provider" "identity_provider" {
     ignore_changes = [
       # SAML provider auto-managed fields
       provider_details["ActiveEncryptionCertificate"],
+      provider_details["SSORedirectBindingURI"], # Auto-derived by AWS from the SAML metadata SingleSignOnService (HTTP-Redirect)
 
       # OAuth provider auto-managed fields that may cause drift
       provider_details["authorize_url"], # May be updated via OIDC discovery


### PR DESCRIPTION
## Problem

SAML identity providers show a **perpetual** in-place `provider_details` update
on every `terraform plan`:

```
~ resource "aws_cognito_identity_provider" "identity_provider" {
  ~ provider_details = {
      - "SSORedirectBindingURI" = "https://accounts.google.com/o/saml2/idp?idpid=..." -> null
        # (other elements unchanged)
    }
}
```

AWS **auto-derives** `SSORedirectBindingURI` from the `MetadataFile`
`<md:SingleSignOnService ... HTTP-Redirect>` binding on read. The practitioner
never sets it, so Terraform plans to remove it (`-> null`) on every run, and it
comes back on every apply — classic perpetual no-op drift.

This is the same class of AWS-managed field the SAML section already covers with
`ActiveEncryptionCertificate`. PR #416 fixed the equivalent **Google/Apple OAuth**
drift and explicitly left SAML residual fields out of scope; this closes the
remaining **metadata-derived** SAML gap.

## Change

One key appended to the SAML block of `lifecycle.ignore_changes`:

```hcl
# SAML provider auto-managed fields
provider_details["ActiveEncryptionCertificate"],
provider_details["SSORedirectBindingURI"], # Auto-derived by AWS from the SAML metadata SingleSignOnService (HTTP-Redirect)
```

**Additive only** — no existing line, comment, or alignment changes; `terraform fmt`
is clean.

## Why this is safe

`SSORedirectBindingURI` is **metadata-derived**, not practitioner-managed. It is
computed by AWS from the `MetadataFile` the practitioner already supplies, so
ignoring it drops **no** legitimate configuration. This is deliberately narrow:
practitioner-set SAML fields (`MetadataFile`, `IDPSignout`, `IDPInit`,
`EncryptedResponses`, `RequestSigningAlgorithm`) are **not** touched, so real
updates to those are still tracked.

## Testing

Against a real Google Workspace SAML IdP (aws provider v6.x):

- **Before:** every plan shows `- "SSORedirectBindingURI" ... -> null` (1 to change).
- **After:** `No changes. Your infrastructure matches the configuration.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
