### PR TITLE
fix: align ui customization client fallback keys

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,7 +34,9 @@ This release fixes UI customization handling for clients without configured name
 
 For clients where `name` is omitted, the module now uses a deterministic fallback key/name such as `client_0`. Previous versions could fail during planning or silently skip the `aws_cognito_user_pool_ui_customization` resource.
 
-For clients explicitly configured with `name = ""`, the module preserves the historical Terraform key shape such as `_0` to avoid unnecessary state address churn. The module now also sends a non-empty fallback name such as `_0` to Cognito for these clients because the AWS provider marks the client `name` argument as required. Review plans for a possible in-place name update on clients that previously used an explicit empty string.
+Clients with omitted `name` also use a new Terraform resource address for the client itself, from a possible historical `aws_cognito_user_pool_client.client["_0"]` address to `aws_cognito_user_pool_client.client["client_0"]`. Because the old key format caused planning errors in practice, this is unlikely to affect existing workspaces, but verify with `terraform state list` before applying if you previously configured clients without names.
+
+For clients explicitly configured with `name = ""`, the module preserves the historical Terraform key shape such as `_0` to avoid unnecessary state address churn. The module now also sends a non-empty fallback name such as `_0` to Cognito for these clients because the AWS provider marks the client `name` argument as required. Review plans for a possible in-place name update from `""` to the key shape such as `_0`; this should not require resource replacement.
 
 After upgrading, review `terraform plan` carefully. Some configurations may now show net-new `aws_cognito_user_pool_ui_customization` resources because they were previously skipped. If you somehow have state for an old hyphenated UI customization address such as:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -28,6 +28,36 @@ user_pool_add_ons {
 }
 ```
 
+## ⚠️ State note: UI customization for clients without names
+
+This release fixes UI customization handling for clients without configured names. Named clients are unaffected.
+
+For clients where `name` is omitted, the module now uses a deterministic fallback key/name such as `client_0`. Previous versions could fail during planning or silently skip the `aws_cognito_user_pool_ui_customization` resource.
+
+For clients explicitly configured with `name = ""`, the module preserves the historical Terraform key shape such as `_0` to avoid unnecessary state address churn.
+
+After upgrading, review `terraform plan` carefully. Some configurations may now show net-new `aws_cognito_user_pool_ui_customization` resources because they were previously skipped. If you somehow have state for an old hyphenated UI customization address such as:
+
+```hcl
+module.<your_module_name>.aws_cognito_user_pool_ui_customization.ui_customization["client-0"]
+```
+
+and Terraform proposes recreation at:
+
+```hcl
+module.<your_module_name>.aws_cognito_user_pool_ui_customization.ui_customization["client_0"]
+```
+
+prefer a manual state move after reviewing the plan:
+
+```bash
+terraform state mv \
+  'module.<your_module_name>.aws_cognito_user_pool_ui_customization.ui_customization["client-0"]' \
+  'module.<your_module_name>.aws_cognito_user_pool_ui_customization.ui_customization["client_0"]'
+```
+
+This module release intentionally does not add static `moved` blocks for this edge case because the old hyphenated address was not a reliable, generally creatable state shape and Terraform `moved` blocks cannot express dynamic moves for arbitrary client indexes.
+
 ## ⚠️ Action required: documented defaults now match module code
 
 > ⚠️ **Review these defaults before upgrading.** This release regenerates the README input table with current module defaults. The module code already used these defaults before this release, but the published README table was stale. If your configuration relied on the previously documented values, pin the variables explicitly before applying.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,7 +34,7 @@ This release fixes UI customization handling for clients without configured name
 
 For clients where `name` is omitted, the module now uses a deterministic fallback key/name such as `client_0`. Previous versions could fail during planning or silently skip the `aws_cognito_user_pool_ui_customization` resource.
 
-For clients explicitly configured with `name = ""`, the module preserves the historical Terraform key shape such as `_0` to avoid unnecessary state address churn.
+For clients explicitly configured with `name = ""`, the module preserves the historical Terraform key shape such as `_0` to avoid unnecessary state address churn. The module now also sends a non-empty fallback name such as `_0` to Cognito for these clients because the AWS provider marks the client `name` argument as required. Review plans for a possible in-place name update on clients that previously used an explicit empty string.
 
 After upgrading, review `terraform plan` carefully. Some configurations may now show net-new `aws_cognito_user_pool_ui_customization` resources because they were previously skipped. If you somehow have state for an old hyphenated UI customization address such as:
 

--- a/client.tf
+++ b/client.tf
@@ -1,8 +1,5 @@
 resource "aws_cognito_user_pool_client" "client" {
-  for_each = var.enabled ? {
-    for idx, client in local.clients :
-    "${lookup(client, "name", null) == null ? "client" : lookup(client, "name", null)}_${idx}" => client
-  } : {}
+  for_each = var.enabled ? local.clients_by_key : {}
 
   allowed_oauth_flows                           = try(each.value.allowed_oauth_flows, null)
   allowed_oauth_flows_user_pool_client          = try(each.value.allowed_oauth_flows_user_pool_client, null)
@@ -114,5 +111,24 @@ locals {
   ]
 
   clients = length(var.clients) == 0 && (var.client_name == null || var.client_name == "") ? [] : (length(var.clients) > 0 ? local.clients_parsed : local.clients_default)
+
+  # Shared client keys for resource addressing and downstream client ID lookups.
+  # - omitted/null name: deterministic fallback key such as client_0
+  # - explicit empty name: preserve historical Terraform key shape such as _0
+  # - non-empty name: preserve the existing name_<idx> resource key shape
+  client_resource_keys = [
+    for idx, client in local.clients :
+    client.name == null ? "client_${idx}" : "${client.name}_${idx}"
+  ]
+
+  clients_by_key = {
+    for idx, client in local.clients :
+    local.client_resource_keys[idx] => client
+  }
+
+  client_lookup_keys = [
+    for idx, client in local.clients :
+    client.name == null || client.name == "" ? local.client_resource_keys[idx] : client.name
+  ]
 
 }

--- a/client.tf
+++ b/client.tf
@@ -1,7 +1,7 @@
 resource "aws_cognito_user_pool_client" "client" {
   for_each = var.enabled ? {
     for idx, client in local.clients :
-    "${coalesce(lookup(client, "name", null), "client")}_${idx}" => client
+    "${lookup(client, "name", null) == null ? "client" : lookup(client, "name", null)}_${idx}" => client
   } : {}
 
   allowed_oauth_flows                           = try(each.value.allowed_oauth_flows, null)

--- a/client.tf
+++ b/client.tf
@@ -1,7 +1,7 @@
 resource "aws_cognito_user_pool_client" "client" {
   for_each = var.enabled ? {
     for idx, client in local.clients :
-    "${lookup(client, "name", "client")}_${idx}" => client
+    "${coalesce(lookup(client, "name", null), "client")}_${idx}" => client
   } : {}
 
   allowed_oauth_flows                           = try(each.value.allowed_oauth_flows, null)
@@ -13,7 +13,7 @@ resource "aws_cognito_user_pool_client" "client" {
   explicit_auth_flows                           = try(each.value.explicit_auth_flows, null)
   generate_secret                               = try(each.value.generate_secret, null)
   logout_urls                                   = try(each.value.logout_urls, null)
-  name                                          = try(each.value.name, null)
+  name                                          = coalesce(try(each.value.name, null), each.key)
   read_attributes                               = try(each.value.read_attributes, null)
   access_token_validity                         = try(each.value.access_token_validity, null)
   id_token_validity                             = try(each.value.id_token_validity, null)

--- a/client.tf
+++ b/client.tf
@@ -126,6 +126,7 @@ locals {
     local.client_resource_keys[idx] => client
   }
 
+  # Used by ui-customization.tf to resolve client IDs with the same key strategy.
   client_lookup_keys = [
     for idx, client in local.clients :
     client.name == null || client.name == "" ? local.client_resource_keys[idx] : client.name

--- a/ui-customization.tf
+++ b/ui-customization.tf
@@ -6,27 +6,22 @@ locals {
     coalesce(c.name, k) => c.id
   }
 
-  # Create UI customizations map using local.clients for consistency
-  # Preserves backward-compatible key format to avoid resource recreation
-  client_ui_customizations = {
+  # Create UI customizations map using the same fallback key format as
+  # aws_cognito_user_pool_client.client so unnamed clients resolve to their IDs.
+  client_ui_customizations = var.enabled ? {
     for idx, c in local.clients :
-    coalesce(lookup(c, "name", null), "client-${idx}") => {
+    coalesce(lookup(c, "name", null), "client_${idx}") => {
       css        = try(c.ui_customization_css, null)
       image_file = try(c.ui_customization_image_file, null)
     } if try(c.ui_customization_css, null) != null || try(c.ui_customization_image_file, null) != null
-  }
+  } : {}
 }
 
 # UI customizations for specific clients
 resource "aws_cognito_user_pool_ui_customization" "ui_customization" {
-  # Only create resources for clients that still exist in client_ids_map
-  for_each = {
-    for k, v in local.client_ui_customizations :
-    k => v
-    if contains(keys(local.client_ids_map), k)
-  }
+  for_each = local.client_ui_customizations
 
-  client_id = lookup(local.client_ids_map, each.key, null)
+  client_id = local.client_ids_map[each.key]
 
   css        = each.value.css
   image_file = each.value.image_file

--- a/ui-customization.tf
+++ b/ui-customization.tf
@@ -11,7 +11,7 @@ locals {
   # Preserve the historical empty-string client key (_${idx}) for state safety.
   client_ui_customizations = var.enabled ? {
     for idx, c in local.clients :
-    lookup(c, "name", null) == null ? "client_${idx}" : (lookup(c, "name", null) == "" ? "_${idx}" : lookup(c, "name", null)) => {
+    local.client_lookup_keys[idx] => {
       css        = try(c.ui_customization_css, null)
       image_file = try(c.ui_customization_image_file, null)
     } if try(c.ui_customization_css, null) != null || try(c.ui_customization_image_file, null) != null

--- a/ui-customization.tf
+++ b/ui-customization.tf
@@ -8,9 +8,10 @@ locals {
 
   # Create UI customizations map using the same fallback key format as
   # aws_cognito_user_pool_client.client so unnamed clients resolve to their IDs.
+  # Preserve the historical empty-string client key (_${idx}) for state safety.
   client_ui_customizations = var.enabled ? {
     for idx, c in local.clients :
-    coalesce(lookup(c, "name", null), "client_${idx}") => {
+    lookup(c, "name", null) == null ? "client_${idx}" : (lookup(c, "name", null) == "" ? "_${idx}" : lookup(c, "name", null)) => {
       css        = try(c.ui_customization_css, null)
       image_file = try(c.ui_customization_image_file, null)
     } if try(c.ui_customization_css, null) != null || try(c.ui_customization_image_file, null) != null


### PR DESCRIPTION
## Summary
- Align UI customization fallback keys with the actual `aws_cognito_user_pool_client.client` addresses
- Fix omitted-name clients by using the deterministic `client_<idx>` fallback for both the client resource key and UI customization lookup key
- Preserve the historical empty-string client address (`_<idx>`) for state safety instead of converting it to `client_<idx>`
- Extract shared client key locals (`client_resource_keys`, `clients_by_key`, `client_lookup_keys`) so `client.tf` and `ui-customization.tf` use one key-generation path instead of repeating `lookup()` logic
- Preserve disabled-module behavior by making `client_ui_customizations` empty when `var.enabled = false`
- Replace the defensive skip/lookup with a direct map lookup so future key regressions fail explicitly instead of silently omitting UI customization resources
- Document state/upgrade handling in `MIGRATION.md` without declaring this a breaking change or adding static `moved` blocks

Closes #396

## State / upgrade impact
- Named clients are unaffected.
- Clients with omitted `name` could not plan correctly before because `clients_parsed` materializes `name = null`; they now use the deterministic fallback address/name `client_<idx>` and can create their UI customization resource.
- Clients with omitted `name` also use a new Terraform resource address for the client itself, from a possible historical `aws_cognito_user_pool_client.client["_0"]` address to `aws_cognito_user_pool_client.client["client_0"]`. Because the old key format caused planning errors in practice, this is unlikely to affect existing workspaces, but operators should verify with `terraform state list` if they previously configured clients without names.
- Clients with explicit empty `name = ""` preserve the historical Terraform address shape `_<idx>` for state safety. Their UI customization lookup now uses the same `_<idx>` key. The module also now sends a non-empty fallback name like `_<idx>` to Cognito for these clients because the AWS provider marks the client `name` argument as required; review plans for possible in-place name updates from `""` to `_<idx>` on this edge case.
- Unnamed clients that already set `ui_customization_css` or `ui_customization_image_file` may now show net-new `aws_cognito_user_pool_ui_customization.ui_customization[...]` resources in plan output. That is the intended bug fix for configurations that were previously skipped or failed.
- Operators should review plans before applying. If a workspace somehow has an old hyphenated UI customization state address, `MIGRATION.md` now documents a manual `terraform state mv` path.
- This PR intentionally does not add static Terraform `moved` blocks because the old hyphenated address was not a reliable, generally creatable state shape and Terraform `moved` blocks cannot express dynamic moves for arbitrary client indexes.

## Notes
- I did not include #398 because the referenced Go integration test file is not present in the current repository checkout. This change still removes the silent skip path that #398 was meant to catch.

## Validation
- `terraform fmt -recursive`
- `terraform init -backend=false -input=false && terraform validate -no-color`
- `pre-commit run --files client.tf ui-customization.tf MIGRATION.md`
- `git diff --check`
- Temporary local reproduction module with omitted client `name` + `ui_customization_css`: `terraform plan -refresh=false` planned `aws_cognito_user_pool_client.client["client_0"]` and `aws_cognito_user_pool_ui_customization.ui_customization["client_0"]`
- Temporary local reproduction module with explicit empty `name = ""` + `ui_customization_css`: `terraform plan -refresh=false` planned `aws_cognito_user_pool_client.client["_0"]` and `aws_cognito_user_pool_ui_customization.ui_customization["_0"]`

## Safety
- No Terraform apply or live AWS mutation performed.
