### PR TITLE
fix: use managed login branding provider identifier

### DIFF
--- a/managed-login-branding.tf
+++ b/managed-login-branding.tf
@@ -44,7 +44,7 @@ locals {
   # Create a map of branding configurations for outputs.
   managed_login_branding_map = var.enabled && var.managed_login_branding_enabled ? {
     for k, v in aws_cognito_managed_login_branding.branding : k => {
-      id                        = v.id
+      id                        = v.managed_login_branding_id
       managed_login_branding_id = v.managed_login_branding_id
       client_id                 = v.client_id
       user_pool_id              = v.user_pool_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -147,7 +147,7 @@ output "managed_login_branding_details" {
   value = var.enabled && var.managed_login_branding_enabled ? {
     configurations = {
       for k, v in aws_cognito_managed_login_branding.branding : k => {
-        id                        = v.id
+        id                        = v.managed_login_branding_id
         managed_login_branding_id = v.managed_login_branding_id
         client_id                 = v.client_id
         user_pool_id              = v.user_pool_id


### PR DESCRIPTION
## Summary
- map the backwards-compatible managed login branding `id` output field to `managed_login_branding_id`
- remove the invalid `v.id` references from managed login branding locals and outputs

Closes #432

## Validation
- `terraform fmt -recursive`
- `git diff --check`
- `terraform init -backend=false -input=false` attempted, but provider installation for `hashicorp/aws v6.57.1` did not complete within the local 10-minute tool timeout; no `.terraform` directory or lockfile was left behind
