### PR TITLE
ci: fix Claude allowed tools parsing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -135,10 +135,13 @@ jobs:
 
           # MCP configuration is passed through claude_args for claude-code-action v1.0.74+.
 
-          # Required tool permissions for GitHub commenting (v1.0 format)
+          # Required tool permissions for GitHub commenting (v1.0 format).
+          # Keep Bash tool patterns free of spaces; claude-code-action parses
+          # claude_args shell-style, so patterns like Bash(gh pr comment:*) are
+          # split into invalid tool names and prevent codebot from commenting.
           # Task: enables subagent invocation | Read/Grep/Glob: enables code examination
           # mcp__github_comment__*: enables GitHub comment posting | mcp__github_ci__*: enables CI status checks
-          claude_args: '--model claude-sonnet-4-6 --mcp-config ${{ github.workspace }}/.github/claude-mcp-config.json --allowedTools Task,Read,Grep,Glob,Bash(gh pr comment:*),Bash(gh api:*),mcp__github_comment__*,mcp__github_ci__*,mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs'
+          claude_args: '--model claude-sonnet-4-6 --mcp-config ${{ github.workspace }}/.github/claude-mcp-config.json --allowedTools Task,Read,Grep,Glob,Bash(gh:*),mcp__github_comment__*,mcp__github_ci__*,mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs'
 
           # Set trigger phrase for codebot mentions
           trigger_phrase: "codebot"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -40,7 +40,7 @@ jobs:
           claude_args: >-
             --model claude-sonnet-4-6
             --mcp-config ${{ github.workspace }}/.github/claude-mcp-config.json
-            --allowedTools Bash(pre-commit run --files),Bash(terraform fmt),Bash(terraform validate),Bash(terraform-docs),mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs
+            --allowedTools Bash(pre-commit:*),Bash(terraform:*),Bash(terraform-docs:*),mcp__terraform-server__get_provider_details,mcp__terraform-server__search_providers,mcp__terraform-server__search_modules,mcp__terraform-server__get_module_details,mcp__context7__resolve-library-id,mcp__context7__get-library-docs
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary
- fix Claude/codebot `--allowedTools` entries so Bash tool patterns do not contain spaces
- allow Codebot to use `gh` commands via `Bash(gh:*)` instead of the parsed-invalid `Bash(gh pr comment:*)`
- update the generic Claude workflow Bash patterns similarly for Terraform/pre-commit commands

## Context
The re-triggered Codebot run on #438 completed successfully after #435, but posted no review comment. The run log showed `--allowedTools` had been parsed into invalid entries such as `Bash(gh`, `pr`, and `comment:*)`, followed by many permission denials. This PR removes spaces from Bash tool patterns so claude-code-action can parse the tool allowlist correctly.

## Validation
- Python YAML parse for `.github/workflows/claude-code-review.yml`
- Python YAML parse for `.github/workflows/claude.yml`
- `git diff --check`
