### PR TITLE
ci: prevent codebot self-trigger loops

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,9 +10,14 @@ on:
 jobs:
   # Add eyes reaction to show codebot is working
   eyes-reaction:
+    # Only run on explicit human-authored codebot commands. Without these guards,
+    # codebot's own analysis comments can self-trigger this workflow.
     if: |
-      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, 'codebot') || contains(github.event.comment.body, '@codebot'))) ||
-      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, 'codebot') || contains(github.event.comment.body, '@codebot')))
+      github.event.comment.user.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '@codebot') || startsWith(github.event.comment.body, 'codebot'))) ||
+        (github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '@codebot') || startsWith(github.event.comment.body, 'codebot')))
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 2
     permissions:
@@ -49,9 +54,14 @@ jobs:
 
   # Claude Code Action (using proven claude.yml pattern)
   claude:
+    # Only run on explicit human-authored codebot commands. Without these guards,
+    # codebot's own analysis comments can self-trigger this workflow.
     if: |
-      (github.event_name == 'issue_comment' && (contains(github.event.comment.body, 'codebot') || contains(github.event.comment.body, '@codebot'))) ||
-      (github.event_name == 'pull_request_review_comment' && (contains(github.event.comment.body, 'codebot') || contains(github.event.comment.body, '@codebot')))
+      github.event.comment.user.type != 'Bot' &&
+      (
+        (github.event_name == 'issue_comment' && (startsWith(github.event.comment.body, '@codebot') || startsWith(github.event.comment.body, 'codebot'))) ||
+        (github.event_name == 'pull_request_review_comment' && (startsWith(github.event.comment.body, '@codebot') || startsWith(github.event.comment.body, 'codebot')))
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -71,9 +81,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Get comment body safely
-          COMMENT_BODY="${{ github.event.comment.body }}"
-          SAFE_COMMENT=$(echo "$COMMENT_BODY" | tr -d '`$(){}[]|;&<>' | head -c 500)
+          # Get comment body safely from the event payload. Do not interpolate
+          # github.event.comment.body directly into this shell script: Markdown
+          # backticks in comments are command substitutions in bash.
+          COMMENT_BODY="$(jq -r '.comment.body // ""' "$GITHUB_EVENT_PATH")"
+          SAFE_COMMENT="$(printf '%s' "$COMMENT_BODY" | cut -c1-500 | tr -d '`$(){}[]|;&<>')"
 
           echo "Parsing comment: $SAFE_COMMENT"
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -282,4 +282,38 @@ jobs:
 
             ---
 
-            **CRITICAL FINAL INSTRUCTION**: After completing your analysis, post your complete findings as a comment on this pull request using the GitHub commenting tools available to you.
+            **Required PR Comment Format - MUST FOLLOW:**
+            Post a structured Markdown comment, not a single compressed paragraph. Use this exact shape:
+
+            ```markdown
+            🤖 **Codebot ${{ steps.parse-command.outputs.mode || 'Hunt' }} — <short analysis title>**
+
+            **Scope:** <changed files or PR scope>
+            **Mode:** ${{ steps.parse-command.outputs.mode || 'hunt' }} (${{ steps.parse-command.outputs.focus || 'bugs,security,performance' }})
+
+            ## Verdict: <✅ approve / ⚠️ changes requested / ℹ️ informational>
+
+            ## Findings
+
+            ### Finding 1 — <short title>
+            **Confidence:** <High|Medium|Low> | **Severity:** <Critical|High|Medium|Low|N/A>
+
+            <clear explanation, with file/line references where useful>
+
+            **Recommendation:** <specific next action, or "No change required">
+
+            ### Finding 2 — <short title>
+            **Confidence:** <High|Medium|Low> | **Severity:** <Critical|High|Medium|Low|N/A>
+
+            <clear explanation>
+
+            ## Summary
+            - <concise bullet>
+            - <concise bullet>
+            ```
+
+            If there are no blocking findings, still include the sections above with an approval/informational verdict. Do not collapse the review into inline numbered sentences.
+
+            ---
+
+            **CRITICAL FINAL INSTRUCTION**: After completing your analysis, post your complete structured Markdown findings as a comment on this pull request using the GitHub commenting tools available to you.


### PR DESCRIPTION
## Summary
- prevent codebot from triggering on its own bot-authored analysis comments
- require comment commands to start with `@codebot` or `codebot` instead of matching `codebot` anywhere
- read comment bodies from `$GITHUB_EVENT_PATH` in shell to avoid Markdown backticks being executed as command substitutions

## Test Plan
- `git diff --check`
- local parse simulation with a Codebot Markdown analysis body containing backticks and `Bash(...)` patterns

## Notes
Fixes the failed self-trigger run where Codebot's own analysis comment was parsed as shell.
